### PR TITLE
396-use enum34 for datums

### DIFF
--- a/doc/key_concepts.rst
+++ b/doc/key_concepts.rst
@@ -80,8 +80,8 @@ PosEdit(pos=281, edit=C>T, uncertain=False)
 >>> var.posedit.pos
 Interval(start=281, end=281, uncertain=False)
 >>> var.posedit.pos.start, var.posedit.pos.end
-(BaseOffsetPosition(base=281, offset=0, datum=1, uncertain=False),
- BaseOffsetPosition(base=281, offset=0, datum=1, uncertain=False))
+(BaseOffsetPosition(base=281, offset=0, datum=Datum.CDS_START, uncertain=False),
+ BaseOffsetPosition(base=281, offset=0, datum=Datum.CDS_START, uncertain=False))
 >>> var.posedit.edit
 NARefAlt(ref=C, alt=T, uncertain=False)
 

--- a/doc/quick_start.rst
+++ b/doc/quick_start.rst
@@ -151,7 +151,7 @@ measured from sequence start, CDS start, or CDS end (stop codon),
 coordinates are more complex:
 
 >>> var_c1.posedit.pos.start
-BaseOffsetPosition(base=281, offset=0, datum=1, uncertain=False)
+BaseOffsetPosition(base=281, offset=0, datum=Datum.CDS_START, uncertain=False)
 
 Either way, the sequence coordinate may be accessed via the ``base`` attribute:
 

--- a/doc/quick_start.rst
+++ b/doc/quick_start.rst
@@ -177,7 +177,7 @@ Let's map to the transcript for which this is an intronic variant.
 >>> var_c2
 SequenceVariant(ac=NM_182763.2, type=c, posedit=688+403C>T)
 >>> var_c2.posedit.pos.start
-BaseOffsetPosition(base=688, offset=403, datum=1, uncertain=False)
+BaseOffsetPosition(base=688, offset=403, datum=Datum.CDS_START, uncertain=False)
 
 And, if we attempt to infer a protein consequence for this variant, we get
 the expected uncertain interpretation:

--- a/hgvs/__init__.py
+++ b/hgvs/__init__.py
@@ -45,7 +45,7 @@ SequenceVariant(ac=NM_001637.3, type=c, posedit=1582G>A)
 
 # CDS coordinates use BaseOffsetPosition to support intronic offsets
 >>> var_c.posedit.pos.start
-BaseOffsetPosition(base=1582, offset=0, datum=1, uncertain=False)
+BaseOffsetPosition(base=1582, offset=0, datum=Datum.CDS_START, uncertain=False)
 
 """
 

--- a/hgvs/_data/hgvs.pymeta
+++ b/hgvs/_data/hgvs.pymeta
@@ -145,13 +145,13 @@ p_pos = def_p_pos #| '(' def_p_pos:pos ')' -> pos._set_uncertain()
 r_pos = def_r_pos #| '(' def_r_pos:pos ')' -> pos._set_uncertain()
 
 # definite positions
-def_c_pos = base:b offset:o -> hgvs.location.BaseOffsetPosition(b,o,datum=hgvs.location.CDS_START)
-       | '*' num:b offset:o -> hgvs.location.BaseOffsetPosition(b,o,datum=hgvs.location.CDS_END)
+def_c_pos = base:b offset:o -> hgvs.location.BaseOffsetPosition(b,o,datum=hgvs.enums.Datum.CDS_START)
+       | '*' num:b offset:o -> hgvs.location.BaseOffsetPosition(b,o,datum=hgvs.enums.Datum.CDS_END)
 def_g_pos = (num|'?'->None):pos -> hgvs.location.SimplePosition(pos)
 def_m_pos = (num|'?'->None):pos -> hgvs.location.SimplePosition(pos)
-def_n_pos = base:b offset:o -> hgvs.location.BaseOffsetPosition(b,o,datum=hgvs.location.SEQ_START)
+def_n_pos = base:b offset:o -> hgvs.location.BaseOffsetPosition(b,o,datum=hgvs.enums.Datum.SEQ_START)
 def_p_pos = (term13|aa13):aa num:pos -> hgvs.location.AAPosition(pos,bioutils.sequences.aa_to_aa1(aa))
-def_r_pos = base:b offset:o -> hgvs.location.BaseOffsetPosition(b,o,datum=hgvs.location.SEQ_START)
+def_r_pos = base:b offset:o -> hgvs.location.BaseOffsetPosition(b,o,datum=hgvs.enums.Datum.SEQ_START)
 
 
 ############################################################################

--- a/hgvs/enums.py
+++ b/hgvs/enums.py
@@ -1,4 +1,6 @@
 from hgvs.utils.orderedenum import OrderedEnum
 
 
+Datum = OrderedEnum("Datum", "SEQ_START CDS_START CDS_END")
+
 ValidationLevel = OrderedEnum("ValidationLevel", "VALID WARNING ERROR")

--- a/hgvs/parser.py
+++ b/hgvs/parser.py
@@ -19,6 +19,7 @@ from hgvs.exceptions import HGVSParseError
 
 # The following imports are referenced by fully-qualified name in the
 # hgvs grammar.
+import hgvs.enums
 import hgvs.edit
 import hgvs.hgvsposition
 import hgvs.location

--- a/hgvs/transcriptmapper.py
+++ b/hgvs/transcriptmapper.py
@@ -13,6 +13,7 @@ import hgvs.location
 
 from hgvs.exceptions import HGVSError, HGVSUsageError, HGVSDataNotAvailableError
 from hgvs.utils import build_tx_cigar
+from hgvs.enums import Datum
 
 
 class TranscriptMapper(object):
@@ -148,8 +149,8 @@ class TranscriptMapper(object):
             start_bo, end_bo = end_bo, start_bo
 
         return hgvs.location.BaseOffsetInterval(
-            start=hgvs.location.BaseOffsetPosition(base=start_bo[0], offset=start_bo[1], datum=hgvs.location.SEQ_START),
-            end=hgvs.location.BaseOffsetPosition(base=end_bo[0], offset=end_bo[1], datum=hgvs.location.SEQ_START),
+            start=hgvs.location.BaseOffsetPosition(base=start_bo[0], offset=start_bo[1], datum=Datum.SEQ_START),
+            end=hgvs.location.BaseOffsetPosition(base=end_bo[0], offset=end_bo[1], datum=Datum.SEQ_START),
             uncertain=g_interval.uncertain)
 
     def n_to_g(self, n_interval):
@@ -187,23 +188,23 @@ class TranscriptMapper(object):
         # start
         if n_interval.start.base <= self.cds_start_i:
             cs = n_interval.start.base - (self.cds_start_i + 1)
-            cs_datum = hgvs.location.CDS_START
+            cs_datum = Datum.CDS_START
         elif n_interval.start.base > self.cds_start_i and n_interval.start.base <= self.cds_end_i:
             cs = n_interval.start.base - self.cds_start_i
-            cs_datum = hgvs.location.CDS_START
+            cs_datum = Datum.CDS_START
         else:
             cs = n_interval.start.base - self.cds_end_i
-            cs_datum = hgvs.location.CDS_END
+            cs_datum = Datum.CDS_END
         # end
         if n_interval.end.base <= self.cds_start_i:
             ce = n_interval.end.base - (self.cds_start_i + 1)
-            ce_datum = hgvs.location.CDS_START
+            ce_datum = Datum.CDS_START
         elif n_interval.end.base > self.cds_start_i and n_interval.end.base <= self.cds_end_i:
             ce = n_interval.end.base - self.cds_start_i
-            ce_datum = hgvs.location.CDS_START
+            ce_datum = Datum.CDS_START
         else:
             ce = n_interval.end.base - self.cds_end_i
-            ce_datum = hgvs.location.CDS_END
+            ce_datum = Datum.CDS_END
 
         c_interval = hgvs.location.BaseOffsetInterval(
             start=hgvs.location.BaseOffsetPosition(base=cs, offset=n_interval.start.offset, datum=cs_datum),
@@ -220,18 +221,18 @@ class TranscriptMapper(object):
                     self=self))
 
         # start
-        if c_interval.start.datum == hgvs.location.CDS_START and c_interval.start.base < 0:
+        if c_interval.start.datum == Datum.CDS_START and c_interval.start.base < 0:
             rs = c_interval.start.base + self.cds_start_i + 1
-        elif c_interval.start.datum == hgvs.location.CDS_START and c_interval.start.base > 0:
+        elif c_interval.start.datum == Datum.CDS_START and c_interval.start.base > 0:
             rs = c_interval.start.base + self.cds_start_i
-        elif c_interval.start.datum == hgvs.location.CDS_END:
+        elif c_interval.start.datum == Datum.CDS_END:
             rs = c_interval.start.base + self.cds_end_i
         # end
-        if c_interval.end.datum == hgvs.location.CDS_START and c_interval.end.base < 0:
+        if c_interval.end.datum == Datum.CDS_START and c_interval.end.base < 0:
             re = c_interval.end.base + self.cds_start_i + 1
-        elif c_interval.end.datum == hgvs.location.CDS_START and c_interval.end.base > 0:
+        elif c_interval.end.datum == Datum.CDS_START and c_interval.end.base > 0:
             re = c_interval.end.base + self.cds_start_i
-        elif c_interval.end.datum == hgvs.location.CDS_END:
+        elif c_interval.end.datum == Datum.CDS_END:
             re = c_interval.end.base + self.cds_end_i
 
         if rs <= 0 or re > self.tgt_len:
@@ -239,8 +240,8 @@ class TranscriptMapper(object):
 
         n_interval = hgvs.location.BaseOffsetInterval(
             start=hgvs.location.BaseOffsetPosition(
-                base=rs, offset=c_interval.start.offset, datum=hgvs.location.SEQ_START),
-            end=hgvs.location.BaseOffsetPosition(base=re, offset=c_interval.end.offset, datum=hgvs.location.SEQ_START),
+                base=rs, offset=c_interval.start.offset, datum=Datum.SEQ_START),
+            end=hgvs.location.BaseOffsetPosition(base=re, offset=c_interval.end.offset, datum=Datum.SEQ_START),
             uncertain=c_interval.uncertain)
         return n_interval
 

--- a/hgvs/utils/altseqbuilder.py
+++ b/hgvs/utils/altseqbuilder.py
@@ -14,7 +14,7 @@ import recordtype
 from Bio.Seq import Seq
 
 from ..edit import (Dup, NARefAlt, Repeat)
-from ..location import CDS_START, CDS_END
+from ..enums import Datum
 
 DBG = False
 
@@ -170,11 +170,11 @@ class AltSeqBuilder(object):
         :return "exon", "intron", "five_utr", "three_utr", "whole_gene"
         :rtype str
         """
-        if self._var_c.posedit.pos.start.datum == CDS_END and self._var_c.posedit.pos.end.datum == CDS_END:
+        if self._var_c.posedit.pos.start.datum == Datum.CDS_END and self._var_c.posedit.pos.end.datum == Datum.CDS_END:
             result = self.T_UTR
         elif self._var_c.posedit.pos.start.base < 0 and self._var_c.posedit.pos.end.base < 0:
             result = self.F_UTR
-        elif self._var_c.posedit.pos.start.base < 0 and self._var_c.posedit.pos.end.datum == CDS_END:
+        elif self._var_c.posedit.pos.start.base < 0 and self._var_c.posedit.pos.end.datum == Datum.CDS_END:
             result = self.WHOLE_GENE
         elif self._var_c.posedit.pos.start.offset != 0 or self._var_c.posedit.pos.end.offset != 0:
             # leave out anything intronic for now
@@ -277,7 +277,7 @@ class AltSeqBuilder(object):
         start_end = []
         for pos in (self._var_c.posedit.pos.start, self._var_c.posedit.pos.end):
             # list is zero-based; seq pos is 1-based
-            if pos.datum == CDS_START:
+            if pos.datum == Datum.CDS_START:
                 if pos.base < 0:    # 5' UTR
                     result = cds_start - 1
                 else:    # cds/intron
@@ -285,7 +285,7 @@ class AltSeqBuilder(object):
                         result = (cds_start - 1) + pos.base - 1
                     else:
                         result = (cds_start - 1) + pos.base
-            elif pos.datum == CDS_END:    # 3' UTR
+            elif pos.datum == Datum.CDS_END:    # 3' UTR
                 result = cds_stop + pos.base - 1
             else:
                 raise NotImplementedError("Unsupported/unexpected location")

--- a/tests/test_hgvs_edit.py
+++ b/tests/test_hgvs_edit.py
@@ -7,6 +7,7 @@ from nose.plugins.attrib import attr
 
 import hgvs.edit
 import hgvs.location
+from hgvs.enums import Datum
 from hgvs.exceptions import HGVSError
 
 
@@ -93,8 +94,8 @@ class Test_Edit(unittest.TestCase):
         self.assertEqual(str(hgvs.edit.Inv().type), "inv")
 
     def test_Conv(self):
-        start = hgvs.location.BaseOffsetPosition(base=61, offset=-6, datum=hgvs.location.CDS_START)
-        end = hgvs.location.BaseOffsetPosition(base=22, datum=hgvs.location.CDS_END)
+        start = hgvs.location.BaseOffsetPosition(base=61, offset=-6, datum=Datum.CDS_START)
+        end = hgvs.location.BaseOffsetPosition(base=22, datum=Datum.CDS_END)
         pos = hgvs.location.Interval(start=start, end=end)
         self.assertEqual(str(hgvs.edit.Conv("NM_001166478.1", "c", pos)), "conNM_001166478.1:c.61-6_*22")
         # edit types

--- a/tests/test_hgvs_location.py
+++ b/tests/test_hgvs_location.py
@@ -6,6 +6,7 @@ import unittest
 from nose.plugins.attrib import attr
 
 from hgvs.exceptions import HGVSError, HGVSUnsupportedOperationError
+from hgvs.enums import Datum
 import hgvs.location
 import hgvs.parser
 
@@ -55,7 +56,7 @@ class Test_BaseOffsetPosition(unittest.TestCase):
     def test_success(self):
         # r.5
         cdsp = hgvs.location.BaseOffsetPosition(5)
-        self.assertEqual(cdsp.datum, hgvs.location.SEQ_START)
+        self.assertEqual(cdsp.datum, Datum.SEQ_START)
         self.assertEqual(cdsp.base, 5)
         self.assertEqual(cdsp.offset, 0)
         self.assertEqual(str(cdsp), "5")
@@ -76,8 +77,8 @@ class Test_BaseOffsetPosition(unittest.TestCase):
         self.assertEqual(str(cdsp), "(5+?)")
 
         # c.*5
-        cdsp = hgvs.location.BaseOffsetPosition(5, datum=hgvs.location.CDS_END)
-        self.assertEqual(cdsp.datum, hgvs.location.CDS_END)
+        cdsp = hgvs.location.BaseOffsetPosition(5, datum=Datum.CDS_END)
+        self.assertEqual(cdsp.datum, Datum.CDS_END)
         self.assertEqual(cdsp.base, 5)
         self.assertEqual(cdsp.offset, 0)
         self.assertEqual(str(cdsp), "*5")

--- a/tests/test_hgvs_transcriptmapper.py
+++ b/tests/test_hgvs_transcriptmapper.py
@@ -13,6 +13,7 @@ import hgvs.location
 import hgvs.parser
 from hgvs.exceptions import HGVSError
 from hgvs.transcriptmapper import TranscriptMapper
+from hgvs.enums import Datum
 
 
 @attr(tags=["quick"])
@@ -357,24 +358,24 @@ if __name__ == "__main__":
     #    cds = 24 + 1 # hgvs
     #    # gs, ge = genomic start/end; rs,re = rna start/end; cs, ce = cdna start/end; so, eo = start offset/end offset
     #    test_cases = [
-    #        {"gs": 278204, "ge": 278204, "rs": 1, "re": 1, "so": 0, "eo": 0, "d": hgvs.location.SEQ_START, "cs": 1-cds, "ce": 1-cds},
-    #        {"gs": 278214, "ge": 278214, "rs": 11, "re": 11, "so": 0, "eo": 0, "d": hgvs.location.SEQ_START, "cs": 11-cds, "ce": 11-cds},
-    #        {"gs": 278204, "ge": 278214, "rs": 1, "re": 11, "so": 0, "eo": 0, "d": hgvs.location.SEQ_START, "cs": 1-cds, "ce": 11-cds},
+    #        {"gs": 278204, "ge": 278204, "rs": 1, "re": 1, "so": 0, "eo": 0, "d": Datum.SEQ_START, "cs": 1-cds, "ce": 1-cds},
+    #        {"gs": 278214, "ge": 278214, "rs": 11, "re": 11, "so": 0, "eo": 0, "d": Datum.SEQ_START, "cs": 11-cds, "ce": 11-cds},
+    #        {"gs": 278204, "ge": 278214, "rs": 1, "re": 11, "so": 0, "eo": 0, "d": Datum.SEQ_START, "cs": 1-cds, "ce": 11-cds},
     #
     #        # around cds (cds can"t be zero)
-    #        {"gs": 278227, "ge": 278227, "rs": 24, "re": 24, "so": 0, "eo": 0, "d": hgvs.location.SEQ_START, "cs": 24-cds, "ce": 24-cds},
+    #        {"gs": 278227, "ge": 278227, "rs": 24, "re": 24, "so": 0, "eo": 0, "d": Datum.SEQ_START, "cs": 24-cds, "ce": 24-cds},
     #
     #        # beyond cds add 1 due to hgvs
-    #        {"gs": 278228, "ge": 278228, "rs": 25, "re": 25, "so": 0, "eo": 0, "d": hgvs.location.SEQ_START, "cs": 25-cds+1, "ce": 25-cds+1},
-    #        {"gs": 278229, "ge": 278229, "rs": 26, "re": 26, "so": 0, "eo": 0, "d": hgvs.location.SEQ_START, "cs": 26-cds+1, "ce": 26-cds+1},
-    #        {"gs": 280966, "ge": 280966, "rs": 2760, "re": 2760, "so": 0, "eo": 0, "d": hgvs.location.SEQ_START, "cs": 2760-cds+1, "ce": 2760-cds+1},
-    #        {"gs": 278687, "ge": 278687, "rs": 484, "re": 484, "so": 0, "eo": 0, "d": hgvs.location.SEQ_START, "cs": 484-cds+1, "ce": 484-cds+1},
-    #        {"gs": 278687, "ge": 278688, "rs": 484, "re": 485, "so": 0, "eo": 0, "d": hgvs.location.SEQ_START, "cs": 484-cds+1, "ce": 485-cds+1},
-    #        {"gs": 278688, "ge":278691, "rs": 485, "re": 485, "so": 0, "eo": 0, "d": hgvs.location.SEQ_START, "cs": 485-cds+1, "ce": 485-cds+1},
+    #        {"gs": 278228, "ge": 278228, "rs": 25, "re": 25, "so": 0, "eo": 0, "d": Datum.SEQ_START, "cs": 25-cds+1, "ce": 25-cds+1},
+    #        {"gs": 278229, "ge": 278229, "rs": 26, "re": 26, "so": 0, "eo": 0, "d": Datum.SEQ_START, "cs": 26-cds+1, "ce": 26-cds+1},
+    #        {"gs": 280966, "ge": 280966, "rs": 2760, "re": 2760, "so": 0, "eo": 0, "d": Datum.SEQ_START, "cs": 2760-cds+1, "ce": 2760-cds+1},
+    #        {"gs": 278687, "ge": 278687, "rs": 484, "re": 484, "so": 0, "eo": 0, "d": Datum.SEQ_START, "cs": 484-cds+1, "ce": 484-cds+1},
+    #        {"gs": 278687, "ge": 278688, "rs": 484, "re": 485, "so": 0, "eo": 0, "d": Datum.SEQ_START, "cs": 484-cds+1, "ce": 485-cds+1},
+    #        {"gs": 278688, "ge":278691, "rs": 485, "re": 485, "so": 0, "eo": 0, "d": Datum.SEQ_START, "cs": 485-cds+1, "ce": 485-cds+1},
     #
     #        # around cds_start (24) and cds_end (1236), mindful of *coding* del (3D)
-    #        {"gs": 278204+24, "ge": 278204+1236, "rs": 25, "re": 1237-3, "so": 0, "eo": 0, "d": hgvs.location.SEQ_START, "cs": 25-cds+1, "ce": 1237-cds-3+1},
-    #        {"gs": 280956, "ge": 280966, "rs": 2750, "re": 2760, "so": 0, "eo": 0, "d": hgvs.location.SEQ_START, "cs": 2750-cds+1, "ce': 2760-cds+1},
+    #        {"gs": 278204+24, "ge": 278204+1236, "rs": 25, "re": 1237-3, "so": 0, "eo": 0, "d": Datum.SEQ_START, "cs": 25-cds+1, "ce": 1237-cds-3+1},
+    #        {"gs": 280956, "ge": 280966, "rs": 2750, "re": 2760, "so": 0, "eo": 0, "d": Datum.SEQ_START, "cs": 2750-cds+1, "ce': 2760-cds+1},
     #    ]
     #    self.run_cases(tm, test_cases)
     #
@@ -398,27 +399,27 @@ if __name__ == "__main__":
     #    tm = TranscriptMapper(self.hdp, ac, self.ref)
     #    cds = 208 + 1 # hgvs
     #    test_cases = [
-    #        {"gs": 150552215, "ge": 150552215, "rs": 1, "re": 1, "so": 0, "eo": 0, "d": hgvs.location.SEQ_START , "cs": 1-cds, "ce": 1-cds},
-    #        {"gs": 150552214, "ge": 150552214, "rs": 2, "re": 2, "so": 0, "eo": 0, "d": hgvs.location.SEQ_START , "cs": 2-cds, "ce": 2-cds},
+    #        {"gs": 150552215, "ge": 150552215, "rs": 1, "re": 1, "so": 0, "eo": 0, "d": Datum.SEQ_START , "cs": 1-cds, "ce": 1-cds},
+    #        {"gs": 150552214, "ge": 150552214, "rs": 2, "re": 2, "so": 0, "eo": 0, "d": Datum.SEQ_START , "cs": 2-cds, "ce": 2-cds},
     #
     #        # beyond cds add 1 due to hgvs
-    #        {"gs": 150552007, "ge": 150552007, "rs": 209, "re": 209, "so": 0, "eo": 0, "d": hgvs.location.SEQ_START , "cs": 209-cds+1, "ce": 209-cds+1},
-    #        {"gs": 150547027, "ge": 150547027, "rs": 3842, "re": 3842, "so": 0, "eo": 0, "d": hgvs.location.SEQ_START , "cs": 3842-cds+1, "ce": 3842-cds+1},
+    #        {"gs": 150552007, "ge": 150552007, "rs": 209, "re": 209, "so": 0, "eo": 0, "d": Datum.SEQ_START , "cs": 209-cds+1, "ce": 209-cds+1},
+    #        {"gs": 150547027, "ge": 150547027, "rs": 3842, "re": 3842, "so": 0, "eo": 0, "d": Datum.SEQ_START , "cs": 3842-cds+1, "ce": 3842-cds+1},
     #
-    #        #{"gs": 150549968, "ge": 150549968, "rs": 897, "re": 897, "so": 0, "eo": 0, "d": hgvs.location.SEQ_START , "cs": 897-cds+1, "ce": 897-cds+1},
-    #        {"gs": 150551318, "ge": 150551318, "rs": 897, "re": 897, "so": 1, "eo": 1, "d": hgvs.location.SEQ_START , "cs": 897-cds+1, "ce": 897-cds+1},
-    #        {"gs": 150551318, "ge": 150551319, "rs": 897, "re": 897, "so": 1, "eo": 0, "d": hgvs.location.SEQ_START , "cs": 897-cds+1, "ce": 897-cds+1},
-    #        {"gs": 150551317, "ge": 150551318, "rs": 897, "re": 897, "so": 2, "eo": 1, "d": hgvs.location.SEQ_START , "cs": 897-cds+1, "ce": 897-cds+1},
-    #        {"gs": 150549968, "ge": 150549969, "rs": 897, "re": 897, "so": 0, "eo": -1, "d": hgvs.location.SEQ_START , "cs": 897-cds+1, "ce": 897-cds+1},
-    #        {"gs": 150549969, "ge": 150549970, "rs": 897, "re": 897, "so": -1, "eo": -2, "d": hgvs.location.SEQ_START , "cs": 897-cds+1, "ce": 897-cds+1},
+    #        #{"gs": 150549968, "ge": 150549968, "rs": 897, "re": 897, "so": 0, "eo": 0, "d": Datum.SEQ_START , "cs": 897-cds+1, "ce": 897-cds+1},
+    #        {"gs": 150551318, "ge": 150551318, "rs": 897, "re": 897, "so": 1, "eo": 1, "d": Datum.SEQ_START , "cs": 897-cds+1, "ce": 897-cds+1},
+    #        {"gs": 150551318, "ge": 150551319, "rs": 897, "re": 897, "so": 1, "eo": 0, "d": Datum.SEQ_START , "cs": 897-cds+1, "ce": 897-cds+1},
+    #        {"gs": 150551317, "ge": 150551318, "rs": 897, "re": 897, "so": 2, "eo": 1, "d": Datum.SEQ_START , "cs": 897-cds+1, "ce": 897-cds+1},
+    #        {"gs": 150549968, "ge": 150549969, "rs": 897, "re": 897, "so": 0, "eo": -1, "d": Datum.SEQ_START , "cs": 897-cds+1, "ce": 897-cds+1},
+    #        {"gs": 150549969, "ge": 150549970, "rs": 897, "re": 897, "so": -1, "eo": -2, "d": Datum.SEQ_START , "cs": 897-cds+1, "ce": 897-cds+1},
     #
     #        # exon 2, 4nt insertion ~ r.2760
     #        # See http://tinyurl.com/mwegybw
     #        # The coords of this indel via NW alignment differ from those at NCBI, but are the same canonicalized
     #        # variant.  Nothing to do about that short of running Splign ourselves.  Test a few examples.
-    #        {"gs": 150548892, "ge": 150548892, "rs": 1973, "re": 1973, "so": 0, "eo":0, "d": hgvs.location.SEQ_START , "cs": 1973-cds+1, "ce": 1973-cds+1},
-    #        #? {"gs": 150548891, "ge": 150548892, "rs": 1972, "re": 1973, "so": 0, "eo":0, "d": hgvs.location.SEQ_START , "cs": 1972-cds+1, "ce": 1973-cds+1},
-    #        {"gs": 150548890, "ge": 150548892, "rs": 1973, "re": 1979, "so": 0, "eo":0, "d": hgvs.location.SEQ_START , "cs": 1973-cds+1, "ce": 1979-cds+1},
+    #        {"gs": 150548892, "ge": 150548892, "rs": 1973, "re": 1973, "so": 0, "eo":0, "d": Datum.SEQ_START , "cs": 1973-cds+1, "ce": 1973-cds+1},
+    #        #? {"gs": 150548891, "ge": 150548892, "rs": 1972, "re": 1973, "so": 0, "eo":0, "d": Datum.SEQ_START , "cs": 1972-cds+1, "ce": 1973-cds+1},
+    #        {"gs": 150548890, "ge": 150548892, "rs": 1973, "re": 1979, "so": 0, "eo":0, "d": Datum.SEQ_START , "cs": 1973-cds+1, "ce": 1979-cds+1},
     #    ]
     #    self.run_cases(tm, test_cases)
     #
@@ -474,17 +475,17 @@ if __name__ == "__main__":
     #    tm = TranscriptMapper(self.hdp, ac, self.ref)
     #    cds = 254 + 1 # hgvs
     #    test_cases = [
-    #        #{"gs": 94547639, "ge": 94547639, "rs": 1, "re": 1, "so": 0, "eo": 0, "d": hgvs.location.SEQ_START, "cs": 1-cds, "ce": 1-cds},
-    #        #{"gs": 94547796, "ge": 94547796, "rs": 158, "re": 158, "so": 0, "eo": 0, "d": hgvs.location.SEQ_START, "cs": 158-cds, "ce": 158-cds},
-    #        #{"gs": 94563185, "ge": 94563185, "rs": 159, "re": 159, "so": -2, "eo": -2, "d": hgvs.location.SEQ_START, "cs": 159-cds, "ce": 159-cds},
+    #        #{"gs": 94547639, "ge": 94547639, "rs": 1, "re": 1, "so": 0, "eo": 0, "d": Datum.SEQ_START, "cs": 1-cds, "ce": 1-cds},
+    #        #{"gs": 94547796, "ge": 94547796, "rs": 158, "re": 158, "so": 0, "eo": 0, "d": Datum.SEQ_START, "cs": 158-cds, "ce": 158-cds},
+    #        #{"gs": 94563185, "ge": 94563185, "rs": 159, "re": 159, "so": -2, "eo": -2, "d": Datum.SEQ_START, "cs": 159-cds, "ce": 159-cds},
     #
     #        # beyond cds add 1 due to hgvs
-    #        #{"gs": 94567118, "ge": 94567120, "rs": 316, "re": 316, "so": 0, "eo": 2, "d": hgvs.location.SEQ_START, "cs": 316-cds+1, "ce": 316-cds+1},
-    #        {"gs": 94567115, "ge": 94567118, "rs": 313, "re": 316, "so": 0, "eo": 0, "d": hgvs.location.SEQ_START, "cs": 313-cds+1, "ce": 316-cds+1},
+    #        #{"gs": 94567118, "ge": 94567120, "rs": 316, "re": 316, "so": 0, "eo": 2, "d": Datum.SEQ_START, "cs": 316-cds+1, "ce": 316-cds+1},
+    #        {"gs": 94567115, "ge": 94567118, "rs": 313, "re": 316, "so": 0, "eo": 0, "d": Datum.SEQ_START, "cs": 313-cds+1, "ce": 316-cds+1},
     #
     #        # intron in the middle between exon 1 and 2
-    #        #{"gs": 94555500, "ge": 94555501, "rs": 157, "re": 158, "so": 7686, "eo": -7685, "d": hgvs.location.SEQ_START, "cs": 157-cds+1, "ce": 158-cds+1},
-    #        #{"gs": 94555481, "ge": 94555501, "rs": 157, "re": 158, "so": 7686, "eo": -7685, "d": hgvs.location.SEQ_START, "cs": 157-cds+1, "ce": 158-cds+1},
+    #        #{"gs": 94555500, "ge": 94555501, "rs": 157, "re": 158, "so": 7686, "eo": -7685, "d": Datum.SEQ_START, "cs": 157-cds+1, "ce": 158-cds+1},
+    #        #{"gs": 94555481, "ge": 94555501, "rs": 157, "re": 158, "so": 7686, "eo": -7685, "d": Datum.SEQ_START, "cs": 157-cds+1, "ce": 158-cds+1},
     #    ]
     #    self.run_cases(tm, test_cases)
 

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -12,6 +12,7 @@ import unittest
 from nose.plugins.attrib import attr
 
 from hgvs.exceptions import HGVSError, HGVSDataNotAvailableError, HGVSParseError, HGVSInvalidVariantError, HGVSInvalidVariantError
+from hgvs.enums import Datum
 import hgvs.dataproviders.uta
 import hgvs.normalizer
 import hgvs.parser
@@ -164,8 +165,8 @@ class Test_Issues(unittest.TestCase):
         # start and end are parsed independently. The * binds to
         # start but not end, causing end to have an incorrect datum.
         v = self.hp.parse_hgvs_variant("NM_004006.2:c.*87_91del")
-        self.assertEqual(v.posedit.pos.start.datum, hgvs.location.CDS_END)
-        self.assertEqual(v.posedit.pos.end.datum,   hgvs.location.CDS_END)
+        self.assertEqual(v.posedit.pos.start.datum, Datum.CDS_END)
+        self.assertEqual(v.posedit.pos.end.datum,   Datum.CDS_END)
         
 
     def test_334_delins_normalization(self):


### PR DESCRIPTION
Use enum34 for datums. All tests passed.