### PR TITLE
424-Include ref seq in ident variant

### DIFF
--- a/hgvs/edit.py
+++ b/hgvs/edit.py
@@ -104,7 +104,7 @@ class NARefAlt(Edit):
         # subst and delins
         if self.ref is not None and self.alt is not None:
             if self.ref == self.alt:
-                s = "{ref}=".format(ref=ref)
+                s = "{self.ref}=".format(self=self)
             elif len(self.alt) == 1 and len(self.ref) == 1 and not self.ref.isdigit():    # don't turn del5insT into 5>T
                 s = "{self.ref}>{self.alt}".format(self=self)
             else:
@@ -435,13 +435,9 @@ class Repeat(Edit):
     def format(self, conf=None):
         if self.min > self.max:
             raise HGVSError("Repeat min count must be less than or equal to max count")
-        max_ref_length = self._format_config_na(conf)
-        ref = self.ref
-        if max_ref_length is not None and (ref is None or len(ref) > max_ref_length):
-            ref = ''
         if self.min == self.max:
-            return "{ref}[{min}]".format(ref=ref, min=self.min)
-        return "{ref}({min}_{max})".format(ref=ref, min=self.min, max=self.max)
+            return "{ref}[{min}]".format(ref=self.ref, min=self.min)
+        return "{ref}({min}_{max})".format(ref=self.ref, min=self.min, max=self.max)
     
     __str__ = format
 

--- a/tests/data/grammar_test.tsv
+++ b/tests/data/grammar_test.tsv
@@ -157,7 +157,7 @@ dna_edit	A>C|delAAinsC|insA|delA|dupA	True	list	A>C|delinsC|insA|del|dup
 dna_edit	A>U|del5A	False	list	
 dna_edit_mu	(A>C)	True	one	
 dna_edit_mu	A>C	True	one	
-dna_ident	=|T=|ACG=	True	list	=|=|=
+dna_ident	=|T=|ACG=	True	list	
 dna_ins	insA|insC|insG|insT	True	list	
 dna_ins	insU	False	one	
 dna_inv	inv	True	list	
@@ -211,7 +211,7 @@ rna_edit	A>C|delAAinsC|insA|delA|dupA	True	list	A>C|delinsC|insA|del|dup
 rna_edit	A>T|del5A	False	list	
 rna_edit_mu	(A>C)	True	one		
 rna_edit_mu	A>C	True	one
-rna_ident	=|U=|UGG=	True	list	=|=|=
+rna_ident	=|U=|UGG=	True	list	
 rna_ins	insAA	True	one	
 rna_ins	insA|insC|insG|insU	True	list	
 rna_ins	insT	False	one	

--- a/tests/test_hgvs_normalizer.py
+++ b/tests/test_hgvs_normalizer.py
@@ -129,7 +129,7 @@ class Test_HGVSNormalizer(unittest.TestCase):
         self.assertEqual(str(self.norm.normalize(self.hp.parse_hgvs_variant(
             "NC_000006.11:g.49917151_49917156delinsTCTAAA"))), "NC_000006.11:g.49917154_49917155delinsAA")
         self.assertEqual(str(self.norm.normalize(self.hp.parse_hgvs_variant(
-            "NC_000003.12:g.46709584_46709610del27insAAGAAGAAGAAGAAGAAGAAGAAGAAG"))), "NC_000003.12:g.46709584_46709610=")
+            "NC_000003.12:g.46709584_46709610del27insAAGAAGAAGAAGAAGAAGAAGAAGAAG"))), "NC_000003.12:g.46709584_46709610AAGAAGAAGAAGAAGAAGAAGAAGAAG=")
 
         #5' shuffling
         self.assertEqual(str(self.norm5.normalize(self.hp.parse_hgvs_variant("NC_000006.11:g.49917122_49917123insA"))),
@@ -145,7 +145,7 @@ class Test_HGVSNormalizer(unittest.TestCase):
         self.assertEqual(str(self.norm5.normalize(self.hp.parse_hgvs_variant(
             "NC_000006.11:g.49917151_49917156delinsTCTAAA"))), "NC_000006.11:g.49917154_49917155delinsAA")
         self.assertEqual(str(self.norm5.normalize(self.hp.parse_hgvs_variant(
-            "NC_000003.12:g.46709584_46709610del27insAAGAAGAAGAAGAAGAAGAAGAAGAAG"))), "NC_000003.12:g.46709584_46709610=")
+            "NC_000003.12:g.46709584_46709610del27insAAGAAGAAGAAGAAGAAGAAGAAGAAG"))), "NC_000003.12:g.46709584_46709610AAGAAGAAGAAGAAGAAGAAGAAGAAG=")
 
         self.assertEqual(str(self.norm.normalize(self.hp.parse_hgvs_variant(
             "NC_000009.11:g.36233991_36233992delCAinsTG"))), "NC_000009.11:g.36233991_36233992inv")

--- a/tests/test_hgvs_sequencevariant.py
+++ b/tests/test_hgvs_sequencevariant.py
@@ -83,7 +83,7 @@ class Test_SequenceVariant(unittest.TestCase):
         var = hp.parse_hgvs_variant("NM_001166478.1:c.35_36dupTC")
         self.assertEqual(str(var), "NM_001166478.1:c.35_36dup")
         var = hp.parse_hgvs_variant("NM_001166478.1:c.31T=")
-        self.assertEqual(str(var), "NM_001166478.1:c.31=")
+        self.assertEqual(str(var), "NM_001166478.1:c.31T=")
         self.assertEqual(var.format(conf = {'max_ref_length' : None}), "NM_001166478.1:c.31T=")
 
 

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -74,7 +74,7 @@ class Test_Issues(unittest.TestCase):
         self.assertEqual(str(v), "NM_206933.2:c.6317=")
 
         v = self.hp.parse_hgvs_variant("NM_206933.2:c.6317C=")
-        self.assertEqual(str(v), "NM_206933.2:c.6317=")
+        self.assertEqual(str(v), "NM_206933.2:c.6317C=")
                                                    
 
     def test_316_provide_ttog_and_gtot_methods(self):


### PR DESCRIPTION
The reference sequence in ident variants got loss because of 0 max_ref_length in formatter.