### PR TITLE
Migrate test runner to use pytest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ SELF:=$(firstword $(MAKEFILE_LIST))
 
 PKG=hgvs
 PKGD=$(subst .,/,${PKG})
-TEST_DIRS:=.,doc,hgvs,tests
+TEST_DIRS:=doc hgvs tests
 
 
 ############################################################################
@@ -68,11 +68,11 @@ bdist bdist_egg bdist_wheel build sdist install: %:
 #=> test: execute tests
 .PHONY: test
 test:
-	python setup.py nosetests -A '(not tags) or ("extra" not in tags)' --tests ${TEST_DIRS}
+	tox -- -m "not extra" $(TEST_DIRS)
 
 #=> test-* -- run tests with specified tag
 test-%:
-	python setup.py nosetests -a 'tags=$*' --tests ${TEST_DIRS}
+	tox -- -m $* $(TEST_DIRS)
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ SELF:=$(firstword $(MAKEFILE_LIST))
 
 PKG=hgvs
 PKGD=$(subst .,/,${PKG})
-TEST_DIRS:=doc hgvs tests
+TEST_DIRS:=doc hgvs tests ./*.rst
 
 
 ############################################################################

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ SELF:=$(firstword $(MAKEFILE_LIST))
 
 PKG=hgvs
 PKGD=$(subst .,/,${PKG})
-TEST_DIRS:=doc hgvs tests ./*.rst
+TEST_DIRS:=doc hgvs tests ./README.rst
 
 
 ############################################################################
@@ -68,10 +68,11 @@ bdist bdist_egg bdist_wheel build sdist install: %:
 #=> test: execute tests
 .PHONY: test
 test:
-	tox -- -m "not extra" $(TEST_DIRS)
+	python setup.py pytest --addopts="--cov=hgvs -m 'not extra' ${TEST_DIRS}"
 
 #=> test-* -- run tests with specified tag
 test-%:
+	python setup.py pytest --addopts="--cov=hgvs -m ${*} ${TEST_DIRS}"
 	tox -- -m $* $(TEST_DIRS)
 
 

--- a/etc/develop.reqs
+++ b/etc/develop.reqs
@@ -6,3 +6,4 @@ sphinx
 sphinx_rtd_theme
 sphinxcontrib-fulltoc>=1.1
 yapf
+tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,18 +4,6 @@ test = pytest
 [bdist_wheel]
 universal = 1
 
-[nosetests]
-cover-package=hgvs
-cover-erase=1
-cover-html=1
-detailed-errors=1
-doctest-extension=rst
-verbosity=2
-with-coverage=1
-with-doctest=1
-with-xunit=1
-doctest-options=+ELLIPSIS,+NORMALIZE_WHITESPACE
-
 [build_sphinx]
 all_files  = 1
 

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(license="Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)",
       ],
       setup_requires=[
           "nose",
+          "pytest",
           "setuptools_scm",
           "wheel",
       ],

--- a/setup.py
+++ b/setup.py
@@ -56,9 +56,13 @@ setup(license="Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)",
           "unicodecsv",
       ],
       setup_requires=[
-          "pytest",
+          "pytest-runner",
           "setuptools_scm",
           "wheel",
+      ],
+      tests_require=[
+          "pytest",
+          "pytest-cov",
       ],
 )
 

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,6 @@ setup(license="Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)",
           "unicodecsv",
       ],
       setup_requires=[
-          "nose",
           "pytest",
           "setuptools_scm",
           "wheel",

--- a/tests/fx-test/test_variant_length.py
+++ b/tests/fx-test/test_variant_length.py
@@ -6,6 +6,7 @@ import os
 import unittest
 
 from nose.plugins.attrib import attr
+import pytest
 
 from hgvs.exceptions import HGVSUnsupportedOperationError
 import hgvs.dataproviders.uta
@@ -13,6 +14,7 @@ import hgvs.parser
 import hgvs.variantmapper
 
 
+@pytest.mark.fx
 @attr(tags=["fx"])
 class Test_VariantLengths(unittest.TestCase):
     """test length_change method for all variant types and cases"""

--- a/tests/fx-test/test_variant_length.py
+++ b/tests/fx-test/test_variant_length.py
@@ -5,7 +5,6 @@ import os
 
 import unittest
 
-from nose.plugins.attrib import attr
 import pytest
 
 from hgvs.exceptions import HGVSUnsupportedOperationError
@@ -15,7 +14,6 @@ import hgvs.variantmapper
 
 
 @pytest.mark.fx
-@attr(tags=["fx"])
 class Test_VariantLengths(unittest.TestCase):
     """test length_change method for all variant types and cases"""
 

--- a/tests/support/crosschecker.py
+++ b/tests/support/crosschecker.py
@@ -4,8 +4,6 @@ import itertools
 import re
 import unittest
 
-from nose.plugins.attrib import attr
-
 from hgvs.exceptions import HGVSDataNotAvailableError
 import hgvs.dataproviders.uta
 import hgvs.edit

--- a/tests/test_clinvar.py
+++ b/tests/test_clinvar.py
@@ -10,7 +10,6 @@ import sys
 import types
 import unittest
 
-from nose.plugins.attrib import attr
 import pytest
 
 import hgvs
@@ -32,7 +31,6 @@ class Test_Clinvar(unittest.TestCase, CrossChecker):
         self.hp = hgvs.parser.Parser()
 
     @pytest.mark.extra
-    @attr(tags=["extra"])
     def test_clinvar(self, fn=data_fn, mod=None):
         """Test genome-transcript projections for 7498 clinvar variants in 4676 against genes
         for both GRCh37 and GRCh38 (when both are available).

--- a/tests/test_clinvar.py
+++ b/tests/test_clinvar.py
@@ -11,6 +11,7 @@ import types
 import unittest
 
 from nose.plugins.attrib import attr
+import pytest
 
 import hgvs
 import hgvs.dataproviders.uta
@@ -30,6 +31,7 @@ class Test_Clinvar(unittest.TestCase, CrossChecker):
         self.vm = hgvs.variantmapper.VariantMapper(self.hdp)
         self.hp = hgvs.parser.Parser()
 
+    @pytest.mark.extra
     @attr(tags=["extra"])
     def test_clinvar(self, fn=data_fn, mod=None):
         """Test genome-transcript projections for 7498 clinvar variants in 4676 against genes

--- a/tests/test_hgvs_assemblymapper.py
+++ b/tests/test_hgvs_assemblymapper.py
@@ -5,7 +5,6 @@ import os
 
 import unittest
 
-from nose.plugins.attrib import attr
 import pytest
 
 from hgvs.exceptions import HGVSInvalidVariantError
@@ -15,7 +14,6 @@ import hgvs.variantmapper
 
 
 @pytest.mark.quick
-@attr(tags=["quick"])
 class Test_VariantMapper(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -159,7 +157,6 @@ class Test_RefReplacement(unittest.TestCase):
 
 
 @pytest.mark.quick
-@attr(tags=["quick"])
 class Test_AssemblyMapper(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/tests/test_hgvs_assemblymapper.py
+++ b/tests/test_hgvs_assemblymapper.py
@@ -6,6 +6,7 @@ import os
 import unittest
 
 from nose.plugins.attrib import attr
+import pytest
 
 from hgvs.exceptions import HGVSInvalidVariantError
 import hgvs.dataproviders.uta
@@ -13,6 +14,7 @@ import hgvs.parser
 import hgvs.variantmapper
 
 
+@pytest.mark.quick
 @attr(tags=["quick"])
 class Test_VariantMapper(unittest.TestCase):
     @classmethod
@@ -156,6 +158,7 @@ class Test_RefReplacement(unittest.TestCase):
                 self.assertEqual(rec[x], pv.format(conf={'max_ref_length' : None}))
 
 
+@pytest.mark.quick
 @attr(tags=["quick"])
 class Test_AssemblyMapper(unittest.TestCase):
     @classmethod

--- a/tests/test_hgvs_edit.py
+++ b/tests/test_hgvs_edit.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 from nose.plugins.attrib import attr
+import pytest
 
 import hgvs.edit
 import hgvs.location
@@ -11,6 +12,8 @@ from hgvs.enums import Datum
 from hgvs.exceptions import HGVSError
 
 
+@pytest.mark.quick
+@pytest.mark.models
 @attr(tags=["quick", "models"])
 class Test_Edit(unittest.TestCase):
     def test_NARefAlt_exceptions(self):

--- a/tests/test_hgvs_edit.py
+++ b/tests/test_hgvs_edit.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import unittest
 
-from nose.plugins.attrib import attr
 import pytest
 
 import hgvs.edit
@@ -14,7 +13,6 @@ from hgvs.exceptions import HGVSError
 
 @pytest.mark.quick
 @pytest.mark.models
-@attr(tags=["quick", "models"])
 class Test_Edit(unittest.TestCase):
     def test_NARefAlt_exceptions(self):
         with self.assertRaises(HGVSError):

--- a/tests/test_hgvs_grammar.py
+++ b/tests/test_hgvs_grammar.py
@@ -6,14 +6,12 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import unittest
 
-from nose.plugins.attrib import attr
 import pytest
 
 import hgvs.parser
 
 
 @pytest.mark.quick
-@attr(tags=["quick"])
 class Test_Parser(unittest.TestCase):
     longMessage = True
 

--- a/tests/test_hgvs_grammar.py
+++ b/tests/test_hgvs_grammar.py
@@ -7,10 +7,12 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 from nose.plugins.attrib import attr
+import pytest
 
 import hgvs.parser
 
 
+@pytest.mark.quick
 @attr(tags=["quick"])
 class Test_Parser(unittest.TestCase):
     longMessage = True

--- a/tests/test_hgvs_hgvsposition.py
+++ b/tests/test_hgvs_hgvsposition.py
@@ -4,12 +4,15 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 from nose.plugins.attrib import attr
+import pytest
 
 import hgvs.hgvsposition
 
 
 class Test_HGVSPosition(unittest.TestCase):
     @attr(tags=["quick", "models"])
+    @pytest.mark.quick
+    @pytest.mark.models
     def test_hgvsposition(self):
         var = hgvs.hgvsposition.HGVSPosition(
             ac="NM_01234.5",

--- a/tests/test_hgvs_hgvsposition.py
+++ b/tests/test_hgvs_hgvsposition.py
@@ -3,14 +3,12 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import unittest
 
-from nose.plugins.attrib import attr
 import pytest
 
 import hgvs.hgvsposition
 
 
 class Test_HGVSPosition(unittest.TestCase):
-    @attr(tags=["quick", "models"])
     @pytest.mark.quick
     @pytest.mark.models
     def test_hgvsposition(self):

--- a/tests/test_hgvs_intervalmapper.py
+++ b/tests/test_hgvs_intervalmapper.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import unittest
 
-from nose.plugins.attrib import attr
 import pytest
 
 import hgvs.exceptions
@@ -11,7 +10,6 @@ import hgvs.intervalmapper
 
 
 @pytest.mark.quick
-@attr(tags=["quick"])
 class Test_IntervalMapper(unittest.TestCase):
     longMessage = True
 

--- a/tests/test_hgvs_intervalmapper.py
+++ b/tests/test_hgvs_intervalmapper.py
@@ -4,11 +4,13 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 from nose.plugins.attrib import attr
+import pytest
 
 import hgvs.exceptions
 import hgvs.intervalmapper
 
 
+@pytest.mark.quick
 @attr(tags=["quick"])
 class Test_IntervalMapper(unittest.TestCase):
     longMessage = True

--- a/tests/test_hgvs_location.py
+++ b/tests/test_hgvs_location.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 from nose.plugins.attrib import attr
+import pytest
 
 from hgvs.exceptions import HGVSError, HGVSUnsupportedOperationError
 from hgvs.enums import Datum
@@ -11,6 +12,8 @@ import hgvs.location
 import hgvs.parser
 
 
+@pytest.mark.quick
+@pytest.mark.models
 @attr(tags=["quick", "models"])
 class Test_SimplePosition(unittest.TestCase):
     @classmethod
@@ -47,6 +50,7 @@ class Test_SimplePosition(unittest.TestCase):
         self.assertTrue(var.posedit.pos.start >= var.posedit.pos.end)
 
 
+@pytest.mark.quick
 @attr(tags=["quick"])
 class Test_BaseOffsetPosition(unittest.TestCase):
     @classmethod
@@ -158,7 +162,7 @@ class Test_BaseOffsetPosition(unittest.TestCase):
 
         
 
-
+@pytest.mark.quick
 @attr(tags=["quick"])
 class Test_AAPosition(unittest.TestCase):
     @classmethod
@@ -185,6 +189,7 @@ class Test_AAPosition(unittest.TestCase):
         self.assertFalse(var.posedit.pos.start > var.posedit.pos.end)
 
 
+@pytest.mark.quick
 @attr(tags=["quick"])
 class Test_Interval(unittest.TestCase):
     def test_Interval(self):

--- a/tests/test_hgvs_location.py
+++ b/tests/test_hgvs_location.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import unittest
 
-from nose.plugins.attrib import attr
 import pytest
 
 from hgvs.exceptions import HGVSError, HGVSUnsupportedOperationError
@@ -14,7 +13,6 @@ import hgvs.parser
 
 @pytest.mark.quick
 @pytest.mark.models
-@attr(tags=["quick", "models"])
 class Test_SimplePosition(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -51,7 +49,6 @@ class Test_SimplePosition(unittest.TestCase):
 
 
 @pytest.mark.quick
-@attr(tags=["quick"])
 class Test_BaseOffsetPosition(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -163,7 +160,6 @@ class Test_BaseOffsetPosition(unittest.TestCase):
         
 
 @pytest.mark.quick
-@attr(tags=["quick"])
 class Test_AAPosition(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -190,7 +186,6 @@ class Test_AAPosition(unittest.TestCase):
 
 
 @pytest.mark.quick
-@attr(tags=["quick"])
 class Test_Interval(unittest.TestCase):
     def test_Interval(self):
         ival = hgvs.location.Interval(hgvs.location.BaseOffsetPosition(base=12,

--- a/tests/test_hgvs_normalizer.py
+++ b/tests/test_hgvs_normalizer.py
@@ -5,7 +5,6 @@ import os
 
 import unittest
 
-from nose.plugins.attrib import attr
 import pytest
 
 from hgvs.exceptions import HGVSUnsupportedOperationError, HGVSInvalidVariantError, HGVSInvalidVariantError
@@ -18,7 +17,6 @@ hdp = hgvs.dataproviders.uta.connect(mode=os.environ.get("HGVS_CACHE_MODE","run"
 
 
 @pytest.mark.normalization
-@attr(tags=["normalization"])
 class Test_HGVSNormalizer(unittest.TestCase):
     """Tests for normalizer"""
 

--- a/tests/test_hgvs_normalizer.py
+++ b/tests/test_hgvs_normalizer.py
@@ -6,6 +6,7 @@ import os
 import unittest
 
 from nose.plugins.attrib import attr
+import pytest
 
 from hgvs.exceptions import HGVSUnsupportedOperationError, HGVSInvalidVariantError, HGVSInvalidVariantError
 import hgvs.dataproviders.uta
@@ -16,6 +17,7 @@ import hgvs.normalizer
 hdp = hgvs.dataproviders.uta.connect(mode=os.environ.get("HGVS_CACHE_MODE","run"), cache="tests/data/cache.hdp")
 
 
+@pytest.mark.normalization
 @attr(tags=["normalization"])
 class Test_HGVSNormalizer(unittest.TestCase):
     """Tests for normalizer"""

--- a/tests/test_hgvs_parser.py
+++ b/tests/test_hgvs_parser.py
@@ -6,6 +6,7 @@ import pprint
 import unittest
 
 from nose.plugins.attrib import attr
+import pytest
 
 from hgvs.exceptions import HGVSParseError
 import hgvs.parser
@@ -27,6 +28,7 @@ class Test_Position(unittest.TestCase):
             v = self.parser.parse_hgvs_variant(var)
             self.assertEqual(var, v.format(conf = {'max_ref_length' : None}), "parse-format roundtrip failed:" + pprint.pformat(v.posedit))
 
+    @pytest.mark.quick
     @attr(tags=["quick"])
     def test_parser_reject(self):
         fn = os.path.join(os.path.dirname(__file__), "data", "reject")
@@ -38,6 +40,7 @@ class Test_Position(unittest.TestCase):
                 self.parser.parse_hgvs_variant(var)
                 self.assertTrue(False, msg="expected HGVSParseError: %s (%s)" % (var, msg))
 
+    @pytest.mark.quick
     @attr(tags=["quick"])
     def test_parser_posedit_special(self):
         # See note in grammar about parsing p.=, p.?, and p.0

--- a/tests/test_hgvs_parser.py
+++ b/tests/test_hgvs_parser.py
@@ -5,7 +5,6 @@ import os
 import pprint
 import unittest
 
-from nose.plugins.attrib import attr
 import pytest
 
 from hgvs.exceptions import HGVSParseError
@@ -29,7 +28,6 @@ class Test_Position(unittest.TestCase):
             self.assertEqual(var, v.format(conf = {'max_ref_length' : None}), "parse-format roundtrip failed:" + pprint.pformat(v.posedit))
 
     @pytest.mark.quick
-    @attr(tags=["quick"])
     def test_parser_reject(self):
         fn = os.path.join(os.path.dirname(__file__), "data", "reject")
         for var in open(fn, "r"):
@@ -41,7 +39,6 @@ class Test_Position(unittest.TestCase):
                 self.assertTrue(False, msg="expected HGVSParseError: %s (%s)" % (var, msg))
 
     @pytest.mark.quick
-    @attr(tags=["quick"])
     def test_parser_posedit_special(self):
         # See note in grammar about parsing p.=, p.?, and p.0
         self.assertEqual(str(self.parser.parse_p_posedit("0")), "0")

--- a/tests/test_hgvs_posedit.py
+++ b/tests/test_hgvs_posedit.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import unittest
 
-from nose.plugins.attrib import attr
 import pytest
 
 import hgvs.edit
@@ -13,7 +12,6 @@ import hgvs.posedit
 
 @pytest.mark.quick
 @pytest.mark.models
-@attr(tags=["quick", "models", "models"])
 class Test_PosEdit(unittest.TestCase):
     def test_PosEdit(self):
         pos = hgvs.location.Interval(

--- a/tests/test_hgvs_posedit.py
+++ b/tests/test_hgvs_posedit.py
@@ -4,12 +4,15 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 from nose.plugins.attrib import attr
+import pytest
 
 import hgvs.edit
 import hgvs.location
 import hgvs.posedit
 
 
+@pytest.mark.quick
+@pytest.mark.models
 @attr(tags=["quick", "models", "models"])
 class Test_PosEdit(unittest.TestCase):
     def test_PosEdit(self):

--- a/tests/test_hgvs_projector.py
+++ b/tests/test_hgvs_projector.py
@@ -6,6 +6,7 @@ import os
 import unittest
 
 from nose.plugins.attrib import attr
+import pytest
 
 import hgvs.dataproviders.uta
 
@@ -27,6 +28,7 @@ class TestHgvsProjector(unittest.TestCase):
         self.assertEqual(pj.project_variant_forward(v1), v2)
         self.assertEqual(pj.project_variant_backward(v2), v1)
 
+    @pytest.mark.quick
     @attr(tags=["quick"])
     def test_rs201430561(self):
         # rs201430561 http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=201430561
@@ -36,6 +38,7 @@ class TestHgvsProjector(unittest.TestCase):
         self.tst_forward_and_backward(var_c[0], var_c[2])
         self.tst_forward_and_backward(var_c[1], var_c[2])
 
+    @pytest.mark.quick
     @attr(tags=["quick"])
     def test_bad_acs(self):
         hgvs_c = ["NM_001197320.1:c.281C>T", "NM_021960.4:c.740C>T", "NM_182763.2:c.688+403C>T"]

--- a/tests/test_hgvs_projector.py
+++ b/tests/test_hgvs_projector.py
@@ -5,7 +5,6 @@ import os
 
 import unittest
 
-from nose.plugins.attrib import attr
 import pytest
 
 import hgvs.dataproviders.uta
@@ -29,7 +28,6 @@ class TestHgvsProjector(unittest.TestCase):
         self.assertEqual(pj.project_variant_backward(v2), v1)
 
     @pytest.mark.quick
-    @attr(tags=["quick"])
     def test_rs201430561(self):
         # rs201430561 http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=201430561
         hgvs_c = ["NM_001197320.1:c.281C>T", "NM_021960.4:c.740C>T", "NM_182763.2:c.688+403C>T"]
@@ -39,7 +37,6 @@ class TestHgvsProjector(unittest.TestCase):
         self.tst_forward_and_backward(var_c[1], var_c[2])
 
     @pytest.mark.quick
-    @attr(tags=["quick"])
     def test_bad_acs(self):
         hgvs_c = ["NM_001197320.1:c.281C>T", "NM_021960.4:c.740C>T", "NM_182763.2:c.688+403C>T"]
         var_c = [self.hp.parse_hgvs_variant(h) for h in hgvs_c]

--- a/tests/test_hgvs_sequencevariant.py
+++ b/tests/test_hgvs_sequencevariant.py
@@ -5,7 +5,6 @@ import os
 
 import unittest
 
-from nose.plugins.attrib import attr
 import pytest
 
 import hgvs
@@ -16,7 +15,6 @@ import hgvs.dataproviders.uta
 
 @pytest.mark.quick
 @pytest.mark.models
-@attr(tags=["quick", "models"])
 class Test_SequenceVariant(unittest.TestCase):
     def test_SequenceVariant(self):
         var = hgvs.sequencevariant.SequenceVariant(ac="AC", type="B", posedit="1234DE>FG")

--- a/tests/test_hgvs_sequencevariant.py
+++ b/tests/test_hgvs_sequencevariant.py
@@ -6,6 +6,7 @@ import os
 import unittest
 
 from nose.plugins.attrib import attr
+import pytest
 
 import hgvs
 import hgvs.sequencevariant
@@ -13,6 +14,8 @@ import hgvs.parser
 import hgvs.dataproviders.uta
 
 
+@pytest.mark.quick
+@pytest.mark.models
 @attr(tags=["quick", "models"])
 class Test_SequenceVariant(unittest.TestCase):
     def test_SequenceVariant(self):

--- a/tests/test_hgvs_transcriptmapper.py
+++ b/tests/test_hgvs_transcriptmapper.py
@@ -6,6 +6,7 @@ import os
 import unittest
 
 from nose.plugins.attrib import attr
+import pytest
 
 import hgvs.dataproviders.uta
 
@@ -16,6 +17,7 @@ from hgvs.transcriptmapper import TranscriptMapper
 from hgvs.enums import Datum
 
 
+@pytest.mark.quick
 @attr(tags=["quick"])
 class Test_transcriptmapper(unittest.TestCase):
     ref = "GRCh37.p10"

--- a/tests/test_hgvs_transcriptmapper.py
+++ b/tests/test_hgvs_transcriptmapper.py
@@ -5,7 +5,6 @@ import os
 
 import unittest
 
-from nose.plugins.attrib import attr
 import pytest
 
 import hgvs.dataproviders.uta
@@ -18,7 +17,6 @@ from hgvs.enums import Datum
 
 
 @pytest.mark.quick
-@attr(tags=["quick"])
 class Test_transcriptmapper(unittest.TestCase):
     ref = "GRCh37.p10"
 

--- a/tests/test_hgvs_validator.py
+++ b/tests/test_hgvs_validator.py
@@ -5,7 +5,6 @@ import os
 
 import unittest
 
-from nose.plugins.attrib import attr
 import pytest
 
 from hgvs.exceptions import HGVSInvalidVariantError
@@ -41,7 +40,6 @@ class Test_HGVSValidator(unittest.TestCase):
 
 @pytest.mark.quick
 @pytest.mark.validation
-@attr(tags=["quick", "validation"])
 class Test_HGVSIntrinsicValidator(unittest.TestCase):
     """Tests for internal validation"""
 
@@ -112,7 +110,6 @@ class Test_HGVSIntrinsicValidator(unittest.TestCase):
 
 
 @pytest.mark.validation
-@attr(tags=["validation"])
 class Test_HGVSExtrinsicValidator(unittest.TestCase):
     """Tests for external validation"""
 

--- a/tests/test_hgvs_validator.py
+++ b/tests/test_hgvs_validator.py
@@ -6,6 +6,7 @@ import os
 import unittest
 
 from nose.plugins.attrib import attr
+import pytest
 
 from hgvs.exceptions import HGVSInvalidVariantError
 import hgvs.dataproviders.uta
@@ -38,6 +39,8 @@ class Test_HGVSValidator(unittest.TestCase):
             self.vr.validate(self.hp.parse_hgvs_variant("AC_01234.5:c.76_78insT"), strict=False)
 
 
+@pytest.mark.quick
+@pytest.mark.validation
 @attr(tags=["quick", "validation"])
 class Test_HGVSIntrinsicValidator(unittest.TestCase):
     """Tests for internal validation"""
@@ -108,6 +111,7 @@ class Test_HGVSIntrinsicValidator(unittest.TestCase):
         self.assertTrue(self.validate_int.validate(self.hp.parse_hgvs_variant("AC_01234.5:c.679del"), strict=False))
 
 
+@pytest.mark.validation
 @attr(tags=["validation"])
 class Test_HGVSExtrinsicValidator(unittest.TestCase):
     """Tests for external validation"""

--- a/tests/test_hgvs_variantmapper.py
+++ b/tests/test_hgvs_variantmapper.py
@@ -5,7 +5,6 @@ import os
 
 import unittest
 
-from nose.plugins.attrib import attr
 import pytest
 
 from hgvs.exceptions import HGVSError, HGVSInvalidVariantError
@@ -15,7 +14,6 @@ import hgvs.variantmapper
 
 
 @pytest.mark.quick
-@attr(tags=["quick"])
 class Test_VariantMapper_Exceptions(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/tests/test_hgvs_variantmapper.py
+++ b/tests/test_hgvs_variantmapper.py
@@ -6,6 +6,7 @@ import os
 import unittest
 
 from nose.plugins.attrib import attr
+import pytest
 
 from hgvs.exceptions import HGVSError, HGVSInvalidVariantError
 import hgvs.dataproviders.uta
@@ -13,6 +14,7 @@ import hgvs.parser
 import hgvs.variantmapper
 
 
+@pytest.mark.quick
 @attr(tags=["quick"])
 class Test_VariantMapper_Exceptions(unittest.TestCase):
     @classmethod

--- a/tests/test_hgvs_variantmapper_gcp.py
+++ b/tests/test_hgvs_variantmapper_gcp.py
@@ -12,6 +12,7 @@ import unittest
 import unicodecsv as csv
 
 from nose.plugins.attrib import attr
+import pytest
 
 from hgvs.exceptions import HGVSError
 import hgvs.dataproviders.uta
@@ -28,6 +29,7 @@ def gxp_file_reader(fn):
         yield rec
 
 
+@pytest.mark.mapping
 @attr(tags=["mapping"])
 class Test_VariantMapper(unittest.TestCase):
     def setUp(self):
@@ -108,11 +110,13 @@ class Test_VariantMapper(unittest.TestCase):
         for rec in gxp_file_reader("tests/data/gcp/DNAH11-dbSNP-NM_001277115.tsv"):
             self._test_gxp_mapping(rec)
 
+    @pytest.mark.regression
     @attr(tags=["regression"])
     def test_regression(self):
         for rec in gxp_file_reader("tests/data/gcp/regression.tsv"):
             self._test_gxp_mapping(rec)
 
+    @pytest.mark.extra
     @attr(tags=["extra"])
     def test_DNAH11_dbSNP_full(self):
         for rec in gxp_file_reader("tests/data/gcp/DNAH11-dbSNP.tsv"):

--- a/tests/test_hgvs_variantmapper_gcp.py
+++ b/tests/test_hgvs_variantmapper_gcp.py
@@ -11,7 +11,6 @@ import unittest
 
 import unicodecsv as csv
 
-from nose.plugins.attrib import attr
 import pytest
 
 from hgvs.exceptions import HGVSError
@@ -30,7 +29,6 @@ def gxp_file_reader(fn):
 
 
 @pytest.mark.mapping
-@attr(tags=["mapping"])
 class Test_VariantMapper(unittest.TestCase):
     def setUp(self):
         self.hdp = hgvs.dataproviders.uta.connect(mode=os.environ.get("HGVS_CACHE_MODE","run"), cache="tests/data/cache.hdp")
@@ -111,13 +109,11 @@ class Test_VariantMapper(unittest.TestCase):
             self._test_gxp_mapping(rec)
 
     @pytest.mark.regression
-    @attr(tags=["regression"])
     def test_regression(self):
         for rec in gxp_file_reader("tests/data/gcp/regression.tsv"):
             self._test_gxp_mapping(rec)
 
     @pytest.mark.extra
-    @attr(tags=["extra"])
     def test_DNAH11_dbSNP_full(self):
         for rec in gxp_file_reader("tests/data/gcp/DNAH11-dbSNP.tsv"):
             self._test_gxp_mapping(rec)

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -9,7 +9,6 @@ import os
 
 import unittest
 
-from nose.plugins.attrib import attr
 import pytest
 
 from hgvs.exceptions import HGVSError, HGVSDataNotAvailableError, HGVSParseError, HGVSInvalidVariantError, HGVSInvalidVariantError
@@ -25,7 +24,6 @@ import hgvs.variantmapper
 
 
 @pytest.mark.issues
-@attr(tags=["issues"])
 class Test_Issues(unittest.TestCase):
     def setUp(self):
         self.hdp = hgvs.dataproviders.uta.connect(mode="store", cache="tests/data/cache.hdp")

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -10,6 +10,7 @@ import os
 import unittest
 
 from nose.plugins.attrib import attr
+import pytest
 
 from hgvs.exceptions import HGVSError, HGVSDataNotAvailableError, HGVSParseError, HGVSInvalidVariantError, HGVSInvalidVariantError
 from hgvs.enums import Datum
@@ -23,6 +24,7 @@ import hgvs.validator
 import hgvs.variantmapper
 
 
+@pytest.mark.issues
 @attr(tags=["issues"])
 class Test_Issues(unittest.TestCase):
     def setUp(self):

--- a/tests/test_issues_04xx.py
+++ b/tests/test_issues_04xx.py
@@ -9,7 +9,6 @@ import os
 
 import unittest
 
-from nose.plugins.attrib import attr
 import pytest
 
 from hgvs.exceptions import HGVSError, HGVSDataNotAvailableError, HGVSParseError, HGVSInvalidVariantError, HGVSInvalidVariantError
@@ -25,7 +24,6 @@ import hgvs.variantmapper
 
 
 @pytest.mark.issues
-@attr(tags=["issues"])
 class Test_Issues(unittest.TestCase):
     def setUp(self):
         self.hdp = hgvs.dataproviders.uta.connect(mode="store", cache="tests/data/cache.hdp")

--- a/tests/test_issues_04xx.py
+++ b/tests/test_issues_04xx.py
@@ -10,6 +10,7 @@ import os
 import unittest
 
 from nose.plugins.attrib import attr
+import pytest
 
 from hgvs.exceptions import HGVSError, HGVSDataNotAvailableError, HGVSParseError, HGVSInvalidVariantError, HGVSInvalidVariantError
 from hgvs.enums import Datum
@@ -23,6 +24,7 @@ import hgvs.validator
 import hgvs.variantmapper
 
 
+@pytest.mark.issues
 @attr(tags=["issues"])
 class Test_Issues(unittest.TestCase):
     def setUp(self):

--- a/tox.ini
+++ b/tox.ini
@@ -6,34 +6,12 @@ setenv =
     PYTHONHASHSEED = 0
 usedevelop = True
 commands =
-    rm -f .coverage
-    py.test -rxs --cov=hgvs -vv --durations=3 --doctest-modules --doctest-glob='*.rst' --doctest-glob='*.txt' {posargs:-m "not extra" doc hgvs tests}
-basepython =
-    py27: python2.7
-    py36: python3.6
-    lint: python3.6
-    mypy: python3.6
-deps =
-    attrs>=16.3.0
-    biocommons.seqrepo
-    biopython>=1.66
-    bioutils>=0.2.2
-    configparser>=3.3.0
-    enum34
-    ipython<6
-    parsley
-    psycopg2!=2.7
-    unicodecsv
-    coverage
-    pytest
-    pytest-cov
-    pytest-runner
-    setuptools_scm
-    wheel
-    pdbpp
+    make test
 whitelist_externals =
-    rm
+    make
+
 [pytest]
+addopts = -rxs --verbose --doctest-modules --doctest-glob='*.rst' --doctest-glob='*.txt'
 doctest_optionflags =
     NORMALIZE_WHITESPACE
     IGNORE_EXCEPTION_DETAIL

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,6 @@ deps =
     parsley
     psycopg2!=2.7
     unicodecsv
-    nose
     coverage
     pytest
     pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,40 @@
+[tox]
+envlist = py27
+
+[testenv]
+setenv =
+    PYTHONHASHSEED = 0
+usedevelop = True
+commands =
+    rm -f .coverage
+    py.test -rxs --cov=hgvs -vv --durations=3 --doctest-modules --doctest-glob='*.rst' --doctest-glob='*.txt' {posargs:-m "not extra" doc hgvs tests}
+basepython =
+    py27: python2.7
+    py36: python3.6
+    lint: python3.6
+    mypy: python3.6
+deps =
+    attrs>=16.3.0
+    biocommons.seqrepo
+    biopython>=1.66
+    bioutils>=0.2.2
+    configparser>=3.3.0
+    enum34
+    ipython<6
+    parsley
+    psycopg2!=2.7
+    unicodecsv
+    nose
+    coverage
+    pytest
+    pytest-cov
+    pytest-runner
+    setuptools_scm
+    wheel
+    pdbpp
+whitelist_externals =
+    rm
+[pytest]
+doctest_optionflags =
+    NORMALIZE_WHITESPACE
+    IGNORE_EXCEPTION_DETAIL


### PR DESCRIPTION
Implements #343 (as a step towards #190) by adding a tox.ini file and migrating the test runner from nose to pytest. As an added benefit, `make test` now runs without manually setting up a virtualenv, as long as you have tox installed, which might allow simplifying the contributing file.

## Changes
- Migrate nose `attr` test tagging to use `pytest.mark`.
- Add tox.ini file with appropriate setup for running the tests on python 2.7.
- Update the `test` and `test-TAG` make targets
- Remove all remaining references to nose.

## Testing

I verified that `make test` and `make test-quick` both pass and run the expected tests. 