### PR TITLE
Python 3: python-modernize and six changes

### DIFF
--- a/hgvs/config.py
+++ b/hgvs/config.py
@@ -59,7 +59,7 @@ class Config(object):
         self._cp.read_file(flo)
 
     def __dir__(self):
-        return self._cp.keys()
+        return list(self._cp.keys())
 
     def __getattr__(self, k):
         # Work around PyCharm bug https://youtrack.jetbrains.com/issue/PY-4213
@@ -75,7 +75,7 @@ class ConfigGroup(object):
         self.__dict__["_section"] = section
 
     def __dir__(self):
-        return self.__dict__["_section"].keys()
+        return list(self.__dict__["_section"].keys())
 
     def __getattr__(self, k):
         return _val_xform(self.__dict__["_section"][k])

--- a/hgvs/dataproviders/interface.py
+++ b/hgvs/dataproviders/interface.py
@@ -11,6 +11,7 @@ import hgvs
 
 from ..decorators.lru_cache import lru_cache, LEARN, RUN, VERIFY
 from ..utils.PersistentDict import PersistentDict
+from six.moves import map
 
 
 class Interface(object):
@@ -93,7 +94,7 @@ class Interface(object):
             maxsize=hgvs.global_config.lru_cache.maxsize, mode=self.mode, cache=self.cache)(self.get_tx_mapping_options)
 
         def _split_version_string(v):
-            versions = map(int, v.split("."))
+            versions = list(map(int, v.split(".")))
             if len(versions) < 2:
                 versions += [0]
             assert len(versions) == 2

--- a/hgvs/dataproviders/interface.py
+++ b/hgvs/dataproviders/interface.py
@@ -12,9 +12,10 @@ import hgvs
 from ..decorators.lru_cache import lru_cache, LEARN, RUN, VERIFY
 from ..utils.PersistentDict import PersistentDict
 from six.moves import map
+import six
 
 
-class Interface(object):
+class Interface(six.with_metaclass(abc.ABCMeta, object)):
     """Variant mapping and validation requires access to external data,
     specifically exon structures, transcript alignments, and protein
     accessions.  In order to isolate the hgvs package from the myriad
@@ -36,8 +37,6 @@ class Interface(object):
     .. _`Universal Transcript Archive (UTA)`: https://github.com/biocommons/uta
     .. _Invitae: http://invitae.com/
     """
-
-    __metaclass__ = abc.ABCMeta
 
     def interface_version(self):
         return 4

--- a/hgvs/dataproviders/uta.py
+++ b/hgvs/dataproviders/uta.py
@@ -24,6 +24,7 @@ import hgvs
 from ..dataproviders.interface import Interface
 from ..exceptions import HGVSError, HGVSDataNotAvailableError
 from .seqfetcher import SeqFetcher
+import six
 
 _logger = logging.getLogger(__name__)
 
@@ -496,7 +497,7 @@ class UTA_postgresql(UTABase):
         self._ensure_schema_exists()
 
         # remap sqlite's ? placeholders to psycopg2's %s
-        self._queries = {k: v.replace('?', '%s') for k, v in self._queries.iteritems()}
+        self._queries = {k: v.replace('?', '%s') for k, v in six.iteritems(self._queries)}
 
     def _ensure_schema_exists(self):
         # N.B. On AWS RDS, information_schema.schemata always returns zero rows

--- a/hgvs/dataproviders/uta.py
+++ b/hgvs/dataproviders/uta.py
@@ -11,7 +11,6 @@ import inspect
 import logging
 import os
 import re
-import urlparse
 
 import psycopg2
 import psycopg2.extras
@@ -19,6 +18,7 @@ import psycopg2.pool
 
 from bioutils.assemblies import make_ac_name_map
 from bioutils.digests import seq_md5
+from six.moves.urllib import parse as urlparse
 
 import hgvs
 from ..dataproviders.interface import Interface

--- a/hgvs/decorators/deprecated.py
+++ b/hgvs/decorators/deprecated.py
@@ -39,13 +39,13 @@ class deprecated(object):
             msg += '; use ' + self.use_instead + ' instead'
 
         def wrapper(*args, **kwargs):
-            fingerprint = (func.__name__, func.func_code.co_filename, func.func_code.co_firstlineno)
+            fingerprint = (func.__name__, func.__code__.co_filename, func.__code__.co_firstlineno)
             if fingerprint not in self.seen:
                 warnings.warn_explicit(
                     msg,
                     category=DeprecationWarning,
-                    filename=func.func_code.co_filename,
-                    lineno=func.func_code.co_firstlineno + 1)
+                    filename=func.__code__.co_filename,
+                    lineno=func.__code__.co_firstlineno + 1)
             self.seen.update([fingerprint])
             return func(*args, **kwargs)
 

--- a/hgvs/edit.py
+++ b/hgvs/edit.py
@@ -17,6 +17,7 @@ from bioutils.sequences import aa_to_aa1, aa1_to_aa3
 
 import hgvs
 from hgvs.exceptions import HGVSError, HGVSUnsupportedOperationError
+import six
 
 
 @attr.s(slots=True)
@@ -67,7 +68,7 @@ class NARefAlt(Edit):
         >>> NARefAlt(7).ref_s
 
         """
-        return self.ref if (isinstance(self.ref, basestring) and self.ref and self.ref[0] in "ACGTUN") else None
+        return self.ref if (isinstance(self.ref, six.string_types) and self.ref and self.ref[0] in "ACGTUN") else None
 
     @property
     def ref_n(self):
@@ -398,7 +399,7 @@ class Dup(Edit):
         """
         returns a string representing the ref sequence, if it is not None and smells like a sequence
         """
-        return self.ref if (isinstance(self.ref, basestring) and self.ref and self.ref[0] in "ACGTUN") else None
+        return self.ref if (isinstance(self.ref, six.string_types) and self.ref and self.ref[0] in "ACGTUN") else None
 
     def _set_uncertain(self):
         """sets the uncertain flag to True; used primarily by the HGVS grammar
@@ -521,7 +522,7 @@ class Inv(Edit):
 
     @property
     def ref_s(self):
-        return self.ref if (isinstance(self.ref, basestring) and self.ref and self.ref[0] in "ACGTUN") else None
+        return self.ref if (isinstance(self.ref, six.string_types) and self.ref and self.ref[0] in "ACGTUN") else None
 
     @property
     def ref_n(self):

--- a/hgvs/intervalmapper.py
+++ b/hgvs/intervalmapper.py
@@ -47,6 +47,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import re
 
 from hgvs.exceptions import HGVSInvalidIntervalError
+from six.moves import range
 
 
 # N.B. This Interval is internal to intervalmapper.py. It is *NOT* the

--- a/hgvs/normalizer.py
+++ b/hgvs/normalizer.py
@@ -13,6 +13,7 @@ import hgvs
 import hgvs.validator
 import hgvs.variantmapper
 from hgvs.exceptions import HGVSDataNotAvailableError, HGVSUnsupportedOperationError, HGVSInvalidVariantError
+from six.moves import range
 
 _logger = logging.getLogger(__name__)
 

--- a/hgvs/parser.py
+++ b/hgvs/parser.py
@@ -111,7 +111,7 @@ class Parser(object):
                     raise HGVSParseError(
                         "{s}: char {exc.position}: {reason}".format(s=s, exc=exc, reason=exc.formatReason()))
 
-            rule_fxn.func_doc = "parse string s using `%s' rule" % rule_name
+            rule_fxn.__doc__ = "parse string s using `%s' rule" % rule_name
             return rule_fxn
 
         exposed_rule_re = re.compile("hgvs_(variant|position)|(c|g|m|n|p|r)"

--- a/hgvs/transcriptmapper.py
+++ b/hgvs/transcriptmapper.py
@@ -14,6 +14,7 @@ import hgvs.location
 from hgvs.exceptions import HGVSError, HGVSUsageError, HGVSDataNotAvailableError
 from hgvs.utils import build_tx_cigar
 from hgvs.enums import Datum
+from six.moves import range
 
 
 class TranscriptMapper(object):

--- a/hgvs/utils/__init__.py
+++ b/hgvs/utils/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import re
+from six.moves import range
 
 
 def build_tx_cigar(exons, strand):

--- a/hgvs/utils/altseq_to_hgvsp.py
+++ b/hgvs/utils/altseq_to_hgvsp.py
@@ -12,6 +12,7 @@ from ..edit import (AAExt, AAFs, AARefAlt, AASub, Dup)
 from ..exceptions import (HGVSError)
 from ..location import (AAPosition, Interval)
 from ..posedit import (PosEdit)
+from six.moves import range
 
 DBG = False
 
@@ -65,7 +66,7 @@ class AltSeqToHgvsp(object):
                 do_delins = False
             elif self._is_substitution:
                 if len(self._ref_seq) == len(self._alt_seq):
-                    diff_pos = [(i, self._ref_seq[i], self._alt_seq[i]) for i in xrange(len(self._ref_seq))
+                    diff_pos = [(i, self._ref_seq[i], self._alt_seq[i]) for i in range(len(self._ref_seq))
                                 if self._ref_seq[i] != self._alt_seq[i]]
                     if len(diff_pos) == 1:
                         (start, deletion, insertion) = diff_pos[0]
@@ -117,7 +118,7 @@ class AltSeqToHgvsp(object):
                         alt_sub = self._alt_seq[start:]
 
                     # from start, get del/ins out to last difference
-                    diff_indices = [i for i in xrange(len(ref_sub)) if ref_sub[i] != alt_sub[i]]
+                    diff_indices = [i for i in range(len(ref_sub)) if ref_sub[i] != alt_sub[i]]
                     if diff_indices:
                         max_diff = diff_indices[-1] + 1
                         insertion.extend(list(alt_sub[:max_diff]))

--- a/hgvs/utils/altseqbuilder.py
+++ b/hgvs/utils/altseqbuilder.py
@@ -15,6 +15,7 @@ from Bio.Seq import Seq
 
 from ..edit import (Dup, NARefAlt, Repeat)
 from ..enums import Datum
+import six
 
 DBG = False
 
@@ -63,7 +64,7 @@ class AltTranscriptData(object):
         :rtype attrs
         """
         if len(seq) > 0:
-            if isinstance(seq, basestring):
+            if isinstance(seq, six.string_types):
                 seq = list(seq)
             seq_cds = seq[cds_start - 1:]
             if len(seq_cds) % 3 != 0:    # padding so biopython won't complain during the conversion

--- a/hgvs/utils/context.py
+++ b/hgvs/utils/context.py
@@ -30,6 +30,7 @@ import re
 from bioutils.sequences import complement
 
 from ..location import Interval, SimplePosition
+from six.moves import range
 
 
 def full_house(am, var, tx_ac=None):

--- a/hgvs/utils/norm.py
+++ b/hgvs/utils/norm.py
@@ -8,6 +8,7 @@ https://github.com/bioinformed/vgraph
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from collections import namedtuple
+from six.moves import range
 
 
 def trim_common_suffixes(strs, min_len=0):

--- a/misc/refalt-repr-examples.py
+++ b/misc/refalt-repr-examples.py
@@ -3,6 +3,7 @@
 import hgvs
 import hgvs.parser
 from tabulate import tabulate
+from six.moves import map
 
 hp = hgvs.parser.Parser()
 
@@ -31,6 +32,6 @@ def gen1(h):
     return [h, v.posedit.edit.ref, v.posedit.edit.alt, v.posedit.edit.type, v.posedit.length_change()]
 
 
-rows = [map(str, gen1(h)) for h in variants]
+rows = [list(map(str, gen1(h))) for h in variants]
 
 print(tabulate(rows, headers=headers)) #, tablefmt="pipe"))

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(license="Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)",
           "ipython<6",          # for hgvs-shell; >=6 for Py3 only
           "parsley",
           "psycopg2!=2.7",  # 2.7 bug: https://github.com/psycopg/psycopg2/issues/517
+          "six",
           "unicodecsv",
       ],
       setup_requires=[

--- a/tests/support/crosschecker.py
+++ b/tests/support/crosschecker.py
@@ -10,6 +10,7 @@ import hgvs.edit
 import hgvs.parser
 import hgvs.sequencevariant
 import hgvs.variantmapper
+from six.moves import map
 
 
 class LineIterator(object):

--- a/tests/test_clinvar.py
+++ b/tests/test_clinvar.py
@@ -51,7 +51,7 @@ class Test_Clinvar(unittest.TestCase, CrossChecker):
                 continue
             print(rec["gene"])
             variants = (self.hp.parse_hgvs_variant(vs) for vs in rec["hgvs_variants"].split())
-            variants = filter(lambda v: v.type in "cg" and not v.ac.startswith("NG"), variants)
+            variants = [v for v in variants if v.type in "cg" and not v.ac.startswith("NG")]
             try:
                 msg = self.crosscheck_variant_group(list(variants))
             except Exception as e:

--- a/tests/test_hgvs_grammar_full.py
+++ b/tests/test_hgvs_grammar_full.py
@@ -32,6 +32,7 @@ import unittest
 import unicodecsv as csv
 
 import hgvs.parser
+from six.moves import map
 
 
 class TestGrammarFull(unittest.TestCase):

--- a/tests/test_hgvs_grammar_full.py
+++ b/tests/test_hgvs_grammar_full.py
@@ -33,6 +33,7 @@ import unicodecsv as csv
 
 import hgvs.parser
 from six.moves import map
+import six
 
 
 class TestGrammarFull(unittest.TestCase):
@@ -78,11 +79,11 @@ class TestGrammarFull(unittest.TestCase):
                 is_valid = True if row["Valid"].lower() == "true" else False
 
                 for key in expected_map:
-                    expected_result = unicode(expected_map[key])
+                    expected_result = six.text_type(expected_map[key])
                     function_to_test = getattr(self.p._grammar(key), row["Func"])
                     row_str = u"{}\t{}\t{}\t{}\t{}".format(row["Func"], key, row["Valid"], "one", expected_result)
                     try:
-                        actual_result = unicode(function_to_test())
+                        actual_result = six.text_type(function_to_test())
                         if not is_valid or (expected_result != actual_result):
                             print("expected: {} actual:{}".format(expected_result, actual_result))
                             fail_cases.append(row_str)

--- a/tests/test_hgvs_intervalmapper.py
+++ b/tests/test_hgvs_intervalmapper.py
@@ -7,6 +7,7 @@ import pytest
 
 import hgvs.exceptions
 import hgvs.intervalmapper
+from six.moves import range
 
 
 @pytest.mark.quick
@@ -76,7 +77,7 @@ class Test_IntervalMapper(unittest.TestCase):
         iv2 = [hgvs.intervalmapper.Interval(1, 5), hgvs.intervalmapper.Interval(5, 5),
                hgvs.intervalmapper.Interval(5, 9)]
 
-        ivp = [hgvs.intervalmapper.IntervalPair(iv1[i], iv2[i]) for i in xrange(len(iv1))]
+        ivp = [hgvs.intervalmapper.IntervalPair(iv1[i], iv2[i]) for i in range(len(iv1))]
         ivm = hgvs.intervalmapper.IntervalMapper(ivp)
         return ivm
 


### PR DESCRIPTION
This pull request makes some progress towards supporting Python 3 (ref #190). The changes were made using the automated fixes from [`python-modernize`](https://python-modernize.readthedocs.io/en/latest/). That library focuses on maintaining a 2/3 compatible codebase using the `six` library. Some of the idioms are a bit ugly, but this improves compatibility with Python 3+ compatibility, and is a no-op on Python 2.

I broke out each fix into a separate commit so it's easy to see why each change was made. Since you squash commits on merge, this shouldn't clutter the commit history.

I also audited the library using my [list of moved & removed imports](https://github.com/lucaswiman/legacy-python-upgrade-guide/blob/6c4779412ee7e27114397ae8c1d40d8886acd062/imports/tox.ini#L2) between python 2 and python 3. The only issue I found was in the use of `urlparse`, which I replaced with `six.moves.urllib.parse` (a drop-in replacement that aliases the contents of `urlparse` on python 2.)

## Testing

I verified that the `tox` test suite passes.