### PR TITLE
453-Fix get_tgt_length for m. var in normalizer

### DIFF
--- a/hgvs/normalizer.py
+++ b/hgvs/normalizer.py
@@ -261,7 +261,7 @@ class Normalizer(object):
     def _get_tgt_length(self, var):
         """Get the total length of the whole reference sequence
         """
-        if var.type == "g":
+        if var.type == "g" or var.type == "m":
             return float("inf")
         else:
             # Get genomic sequence access number for this transcript


### PR DESCRIPTION
The m. variant should be considered the same as the n. variants in get_tgt_length in normalizer when ensuring the variant is within the whole reference sequence.