### PR TITLE
Fix typo in docs

### DIFF
--- a/doc/examples/creating-a-variant.rst
+++ b/doc/examples/creating-a-variant.rst
@@ -21,7 +21,7 @@ Importantly, each of the objects we’re building has a rule in the
 parser, which means that you have the tools to serialize and deserialize
 (parse) each of the components that we’re about to construct.
 
-1. Make an Interval to defined a position of the edit
+1. Make an Interval to define a position of the edit
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code:: ipython3


### PR DESCRIPTION
Fixes a typo in the documentation

https://hgvs.readthedocs.io/en/stable/examples/creating-a-variant.html#make-an-interval-to-defined-a-position-of-the-edit