### PR TITLE
Set search path only when necessary

### DIFF
--- a/tests/bin/connpool-stress-test
+++ b/tests/bin/connpool-stress-test
@@ -19,6 +19,7 @@ import threading
 import sys
 
 from hgvs.exceptions import HGVSError
+import hgvs.assemblymapper
 import hgvs.dataproviders.uta
 import hgvs.parser
 import hgvs.variantmapper
@@ -30,12 +31,12 @@ _logger = logging.getLogger(__name__)
 if __name__ == "__main__":
     hp = hgvs.parser.Parser()
     hdp = hgvs.dataproviders.uta.connect(pooling=True)
-    am = hgvs.variantmapper.AssemblyMapper(hdp, primary_assembly='GRCh37', alt_aln_method='splign')
+    am = hgvs.assemblymapper.AssemblyMapper(hdp, assembly_name='GRCh37', alt_aln_method='splign')
 
     keep_going = True
 
     fn = sys.argv[1]
-    with gzip.open(fn) as fh:
+    with gzip.open(fn, "rt") as fh:
         hset = [l.strip() for l in fh]
     _logger.info("read {n} variants from {fn}".format(n=len(hset), fn=fn))
 


### PR DESCRIPTION
See #570; the PostgreSQL schema search path only needs to be set the first time we use a connection, not every time we acquire a cursor.