### PR TITLE
Update setup.py ipython version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(license="Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)",
           "bioutils>=0.4.0,<1.0",
           "configparser>=3.3.0",
           "enum34",
-          "ipython<6",          # for hgvs-shell; >=6 for Py3 only
+          "ipython",
           "parsley",
           "psycopg2-binary",
           "six",


### PR DESCRIPTION
Remove python2 compatibility version enforcement on ipython. 
Python2 support will be dropped in 1 month and ipython should not be locked at <6.0