### PR TITLE
fix formatting of example docker command

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -112,7 +112,7 @@ Local Installation of UTA (optional)
 @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 
 
-The easiest way to install UTA locally is to use the docker image:
+The easiest way to install UTA locally is to use the docker image::
 
   $ docker run -d --name uta_20170117 -p 15032:5432 biocommons/uta:uta_20170117
 


### PR DESCRIPTION
Without the second colon, the two dashes in the argument `--name` are combined into a single long dash (i.e. `–name`), which causes a syntax error when copying and pasting the command.