### PR TITLE
Catch HGVSInvalidIntervalError within guess-plausible-variant

### DIFF
--- a/misc/experimental/hgvs-guess-plausible-transcripts
+++ b/misc/experimental/hgvs-guess-plausible-transcripts
@@ -17,7 +17,7 @@ import copy
 import logging
 import sys
 
-from hgvs.exceptions import HGVSInvalidVariantError
+from hgvs.exceptions import HGVSInvalidVariantError, HGVSInvalidIntervalError
 import hgvs.dataproviders.uta
 import hgvs.normalizer
 import hgvs.parser
@@ -58,8 +58,8 @@ def generate_plausible_variants(hdp, hv, v):
             hv.validate(v2)
             _logger.debug("  {}: validated".format(v2))
             yield v2
-        except HGVSInvalidVariantError:
-            _logger.debug("  {}: failed".format(v2))
+        except (HGVSInvalidVariantError, HGVSInvalidIntervalError) as e:
+            _logger.debug("  {}: failed: {}: {}".format(v2, type(e).__name__, str(e)))
             pass
 
 


### PR DESCRIPTION
e.g., this dummy deletion was failing `ATM:c.8816_8817del` with an HGVSInvalidIntervalError.  Otherwise it did work :) I think fair to skip it because you do recover other valid variants:

```
In [99]:  pv = list(generate_plausible_variants(hdp, hv, hp.parse_hgvs_variant('ATM:c.8816_8817del')))
DEBUG:__main__:generate_plausible_variants(ATM:c.8816_8817del)
DEBUG:__main__:  NM_001351835.1:c.8816_8817del: failed: HGVSInvalidIntervalError: c.8816 coordinate is out of bounds
DEBUG:hgvs.variantmapper:Replaced reference sequence in NM_001351834.1:c.8816_8817del with GA
DEBUG:__main__:  NM_001351834.1:c.8816_8817del: validated
DEBUG:__main__:  NM_001351836.1:c.8816_8817del: failed: HGVSInvalidIntervalError: c.8816 coordinate is out of bounds
DEBUG:__main__:  NM_000051.3:c.8816_8817del: validated
```