### PR TITLE
issue #606 - catch index error for variants at alignment gap

### DIFF
--- a/hgvs/variantmapper.py
+++ b/hgvs/variantmapper.py
@@ -21,7 +21,7 @@ import hgvs.utils.altseqbuilder as altseqbuilder
 import hgvs.sequencevariant
 import hgvs.validator
 
-from hgvs.exceptions import HGVSDataNotAvailableError, HGVSUnsupportedOperationError, HGVSInvalidVariantError, \
+from hgvs.exceptions import HGVSUnsupportedOperationError, HGVSInvalidVariantError, \
     HGVSInvalidIntervalError
 from hgvs.decorators.lru_cache import lru_cache
 from hgvs.enums import PrevalidationLevel
@@ -162,7 +162,8 @@ class VariantMapper(object):
                                              alt_ac=var_g.ac,
                                              alt_aln_method=alt_aln_method)
 
-        if (mapper.strand == -1 and not hgvs.global_config.mapping.strict_bounds
+        if (mapper.strand == -1
+                and not hgvs.global_config.mapping.strict_bounds
                 and not mapper.g_interval_is_inbounds(var_g.posedit.pos)):
             _logger.info("Renormalizing out-of-bounds minus strand variant on genomic sequence")
             var_g = self.left_normalizer.normalize(var_g)
@@ -184,7 +185,8 @@ class VariantMapper(object):
         var_n = hgvs.sequencevariant.SequenceVariant(ac=tx_ac,
                                                      type="n",
                                                      posedit=hgvs.posedit.PosEdit(pos_n, edit_n))
-        if (self.replace_reference and var_n.posedit.pos.start.base >= 0
+        if (self.replace_reference
+                and var_n.posedit.pos.start.base >= 0
                 and var_n.posedit.pos.end.base < mapper.tgt_len):
             self._replace_reference(var_n)
         if self.add_gene_symbol:

--- a/hgvs/variantmapper.py
+++ b/hgvs/variantmapper.py
@@ -68,13 +68,11 @@ class VariantMapper(object):
     :class:`hgvs.sequencevariant.SequenceVariant`.
 
     """
-
     def __init__(self,
                  hdp,
                  replace_reference=hgvs.global_config.mapping.replace_reference,
                  prevalidation_level=hgvs.global_config.mapping.prevalidation_level,
-                 add_gene_symbol=hgvs.global_config.mapping.add_gene_symbol
-                 ):
+                 add_gene_symbol=hgvs.global_config.mapping.add_gene_symbol):
         """
         :param bool replace_reference: replace reference (entails additional network access)
         :param str prevalidation_level: None or Intrinsic or Extrinsic validation before mapping
@@ -93,8 +91,9 @@ class VariantMapper(object):
             self._validator = hgvs.validator.IntrinsicValidator(strict=False)
         else:
             self._validator = hgvs.validator.Validator(self.hdp, strict=False)
-        self.left_normalizer = hgvs.normalizer.Normalizer(hdp, shuffle_direction=5, variantmapper=self)
-
+        self.left_normalizer = hgvs.normalizer.Normalizer(hdp,
+                                                          shuffle_direction=5,
+                                                          variantmapper=self)
 
     # ############################################################################
     # g⟷t
@@ -104,14 +103,19 @@ class VariantMapper(object):
         if self._validator:
             self._validator.validate(var_g)
         var_g.fill_ref(self.hdp)
-        mapper = self._fetch_AlignmentMapper(
-            tx_ac=tx_ac, alt_ac=var_g.ac, alt_aln_method=alt_aln_method)
+        mapper = self._fetch_AlignmentMapper(tx_ac=tx_ac,
+                                             alt_ac=var_g.ac,
+                                             alt_aln_method=alt_aln_method)
         if mapper.is_coding_transcript:
-            var_out = VariantMapper.g_to_c(
-                self, var_g=var_g, tx_ac=tx_ac, alt_aln_method=alt_aln_method)
+            var_out = VariantMapper.g_to_c(self,
+                                           var_g=var_g,
+                                           tx_ac=tx_ac,
+                                           alt_aln_method=alt_aln_method)
         else:
-            var_out = VariantMapper.g_to_n(
-                self, var_g=var_g, tx_ac=tx_ac, alt_aln_method=alt_aln_method)
+            var_out = VariantMapper.g_to_n(self,
+                                           var_g=var_g,
+                                           tx_ac=tx_ac,
+                                           alt_aln_method=alt_aln_method)
         return var_out
 
     def t_to_g(self, var_t, alt_ac, alt_aln_method=hgvs.global_config.mapping.alt_aln_method):
@@ -120,14 +124,19 @@ class VariantMapper(object):
         if self._validator:
             self._validator.validate(var_t)
         var_t.fill_ref(self.hdp)
-        mapper = self._fetch_AlignmentMapper(
-            tx_ac=var_t.ac, alt_ac=alt_ac, alt_aln_method=alt_aln_method)
+        mapper = self._fetch_AlignmentMapper(tx_ac=var_t.ac,
+                                             alt_ac=alt_ac,
+                                             alt_aln_method=alt_aln_method)
         if var_t.type == "c":
-            var_out = VariantMapper.c_to_g(
-                self, var_c=var_t, alt_ac=alt_ac, alt_aln_method=alt_aln_method)
+            var_out = VariantMapper.c_to_g(self,
+                                           var_c=var_t,
+                                           alt_ac=alt_ac,
+                                           alt_aln_method=alt_aln_method)
         else:
-            var_out = VariantMapper.n_to_g(
-                self, var_n=var_t, alt_ac=alt_ac, alt_aln_method=alt_aln_method)
+            var_out = VariantMapper.n_to_g(self,
+                                           var_n=var_t,
+                                           alt_ac=alt_ac,
+                                           alt_aln_method=alt_aln_method)
         return var_out
 
     # ############################################################################
@@ -149,12 +158,12 @@ class VariantMapper(object):
             raise HGVSInvalidVariantError("Expected a g. variant; got " + str(var_g))
         if self._validator:
             self._validator.validate(var_g)
-        mapper = self._fetch_AlignmentMapper(
-            tx_ac=tx_ac, alt_ac=var_g.ac, alt_aln_method=alt_aln_method)
+        mapper = self._fetch_AlignmentMapper(tx_ac=tx_ac,
+                                             alt_ac=var_g.ac,
+                                             alt_aln_method=alt_aln_method)
 
-        if (mapper.strand == -1
-            and not hgvs.global_config.mapping.strict_bounds
-            and not mapper.g_interval_is_inbounds(var_g.posedit.pos)):
+        if (mapper.strand == -1 and not hgvs.global_config.mapping.strict_bounds
+                and not mapper.g_interval_is_inbounds(var_g.posedit.pos)):
             _logger.info("Renormalizing out-of-bounds minus strand variant on genomic sequence")
             var_g = self.left_normalizer.normalize(var_g)
 
@@ -169,14 +178,14 @@ class VariantMapper(object):
         else:
             # variant at alignment gap
             pos_g = mapper.n_to_g(pos_n)
-            edit_n = hgvs.edit.NARefAlt(
-                ref='', alt=self._get_altered_sequence(mapper.strand, pos_g, var_g))
+            edit_n = hgvs.edit.NARefAlt(ref='',
+                                        alt=self._get_altered_sequence(mapper.strand, pos_g, var_g))
         pos_n.uncertain = var_g.posedit.pos.uncertain
-        var_n = hgvs.sequencevariant.SequenceVariant(
-            ac=tx_ac, type="n", posedit=hgvs.posedit.PosEdit(pos_n, edit_n))
-        if (self.replace_reference
-            and var_n.posedit.pos.start.base >= 0
-            and var_n.posedit.pos.end.base < mapper.tgt_len):
+        var_n = hgvs.sequencevariant.SequenceVariant(ac=tx_ac,
+                                                     type="n",
+                                                     posedit=hgvs.posedit.PosEdit(pos_n, edit_n))
+        if (self.replace_reference and var_n.posedit.pos.start.base >= 0
+                and var_n.posedit.pos.end.base < mapper.tgt_len):
             self._replace_reference(var_n)
         if self.add_gene_symbol:
             self._update_gene_symbol(var_n, var_g.gene)
@@ -200,8 +209,9 @@ class VariantMapper(object):
         if self._validator:
             self._validator.validate(var_n)
         var_n.fill_ref(self.hdp)
-        mapper = self._fetch_AlignmentMapper(
-            tx_ac=var_n.ac, alt_ac=alt_ac, alt_aln_method=alt_aln_method)
+        mapper = self._fetch_AlignmentMapper(tx_ac=var_n.ac,
+                                             alt_ac=alt_ac,
+                                             alt_aln_method=alt_aln_method)
         pos_g = mapper.n_to_g(var_n.posedit.pos)
         if not pos_g.uncertain:
             edit_g = self._convert_edit_check_strand(mapper.strand, var_n.posedit.edit)
@@ -212,11 +222,12 @@ class VariantMapper(object):
         else:
             # variant at alignment gap
             pos_n = mapper.g_to_n(pos_g)
-            edit_g = hgvs.edit.NARefAlt(
-                ref='', alt=self._get_altered_sequence(mapper.strand, pos_n, var_n))
+            edit_g = hgvs.edit.NARefAlt(ref='',
+                                        alt=self._get_altered_sequence(mapper.strand, pos_n, var_n))
         pos_g.uncertain = var_n.posedit.pos.uncertain
-        var_g = hgvs.sequencevariant.SequenceVariant(
-            ac=alt_ac, type="g", posedit=hgvs.posedit.PosEdit(pos_g, edit_g))
+        var_g = hgvs.sequencevariant.SequenceVariant(ac=alt_ac,
+                                                     type="g",
+                                                     posedit=hgvs.posedit.PosEdit(pos_g, edit_g))
         if self.replace_reference:
             self._replace_reference(var_g)
         # No gene symbol for g. variants (actually, *should* for NG, but no way to distinguish)
@@ -242,8 +253,9 @@ class VariantMapper(object):
         if self._validator:
             self._validator.validate(var_g)
         var_g.fill_ref(self.hdp)
-        mapper = self._fetch_AlignmentMapper(
-            tx_ac=tx_ac, alt_ac=var_g.ac, alt_aln_method=alt_aln_method)
+        mapper = self._fetch_AlignmentMapper(tx_ac=tx_ac,
+                                             alt_ac=var_g.ac,
+                                             alt_aln_method=alt_aln_method)
         pos_c = mapper.g_to_c(var_g.posedit.pos)
         if not pos_c.uncertain:
             edit_c = self._convert_edit_check_strand(mapper.strand, var_g.posedit.edit)
@@ -254,11 +266,12 @@ class VariantMapper(object):
         else:
             # variant at alignment gap
             pos_g = mapper.c_to_g(pos_c)
-            edit_c = hgvs.edit.NARefAlt(
-                ref='', alt=self._get_altered_sequence(mapper.strand, pos_g, var_g))
+            edit_c = hgvs.edit.NARefAlt(ref='',
+                                        alt=self._get_altered_sequence(mapper.strand, pos_g, var_g))
         pos_c.uncertain = var_g.posedit.pos.uncertain
-        var_c = hgvs.sequencevariant.SequenceVariant(
-            ac=tx_ac, type="c", posedit=hgvs.posedit.PosEdit(pos_c, edit_c))
+        var_c = hgvs.sequencevariant.SequenceVariant(ac=tx_ac,
+                                                     type="c",
+                                                     posedit=hgvs.posedit.PosEdit(pos_c, edit_c))
         if self.replace_reference:
             self._replace_reference(var_c)
         if self.add_gene_symbol:
@@ -283,8 +296,9 @@ class VariantMapper(object):
         if self._validator:
             self._validator.validate(var_c)
         var_c.fill_ref(self.hdp)
-        mapper = self._fetch_AlignmentMapper(
-            tx_ac=var_c.ac, alt_ac=alt_ac, alt_aln_method=alt_aln_method)
+        mapper = self._fetch_AlignmentMapper(tx_ac=var_c.ac,
+                                             alt_ac=alt_ac,
+                                             alt_aln_method=alt_aln_method)
         pos_g = mapper.c_to_g(var_c.posedit.pos)
         if not pos_g.uncertain:
             edit_g = self._convert_edit_check_strand(mapper.strand, var_c.posedit.edit)
@@ -298,11 +312,12 @@ class VariantMapper(object):
             var_n.posedit.pos = mapper.c_to_n(var_c.posedit.pos)
             var_n.type = 'n'
             pos_n = mapper.g_to_n(pos_g)
-            edit_g = hgvs.edit.NARefAlt(
-                ref='', alt=self._get_altered_sequence(mapper.strand, pos_n, var_n))
+            edit_g = hgvs.edit.NARefAlt(ref='',
+                                        alt=self._get_altered_sequence(mapper.strand, pos_n, var_n))
         pos_g.uncertain = var_c.posedit.pos.uncertain
-        var_g = hgvs.sequencevariant.SequenceVariant(
-            ac=alt_ac, type="g", posedit=hgvs.posedit.PosEdit(pos_g, edit_g))
+        var_g = hgvs.sequencevariant.SequenceVariant(ac=alt_ac,
+                                                     type="g",
+                                                     posedit=hgvs.posedit.PosEdit(pos_g, edit_g))
         if self.replace_reference:
             self._replace_reference(var_g)
         return var_g
@@ -325,8 +340,9 @@ class VariantMapper(object):
         if self._validator:
             self._validator.validate(var_c)
         var_c.fill_ref(self.hdp)
-        mapper = self._fetch_AlignmentMapper(
-            tx_ac=var_c.ac, alt_ac=var_c.ac, alt_aln_method="transcript")
+        mapper = self._fetch_AlignmentMapper(tx_ac=var_c.ac,
+                                             alt_ac=var_c.ac,
+                                             alt_aln_method="transcript")
         pos_n = mapper.c_to_n(var_c.posedit.pos)
         if (isinstance(var_c.posedit.edit, hgvs.edit.NARefAlt)
                 or isinstance(var_c.posedit.edit, hgvs.edit.Dup)
@@ -335,8 +351,9 @@ class VariantMapper(object):
         else:
             raise HGVSUnsupportedOperationError(
                 "Only NARefAlt/Dup/Inv types are currently implemented")
-        var_n = hgvs.sequencevariant.SequenceVariant(
-            ac=var_c.ac, type="n", posedit=hgvs.posedit.PosEdit(pos_n, edit_n))
+        var_n = hgvs.sequencevariant.SequenceVariant(ac=var_c.ac,
+                                                     type="n",
+                                                     posedit=hgvs.posedit.PosEdit(pos_n, edit_n))
         if self.replace_reference:
             self._replace_reference(var_n)
         if self.add_gene_symbol:
@@ -359,8 +376,9 @@ class VariantMapper(object):
         if self._validator:
             self._validator.validate(var_n)
         var_n.fill_ref(self.hdp)
-        mapper = self._fetch_AlignmentMapper(
-            tx_ac=var_n.ac, alt_ac=var_n.ac, alt_aln_method="transcript")
+        mapper = self._fetch_AlignmentMapper(tx_ac=var_n.ac,
+                                             alt_ac=var_n.ac,
+                                             alt_aln_method="transcript")
         pos_c = mapper.n_to_c(var_n.posedit.pos)
         if (isinstance(var_n.posedit.edit, hgvs.edit.NARefAlt)
                 or isinstance(var_n.posedit.edit, hgvs.edit.Dup)
@@ -369,8 +387,9 @@ class VariantMapper(object):
         else:
             raise HGVSUnsupportedOperationError(
                 "Only NARefAlt/Dup/Inv types are currently implemented")
-        var_c = hgvs.sequencevariant.SequenceVariant(
-            ac=var_n.ac, type="c", posedit=hgvs.posedit.PosEdit(pos_c, edit_c))
+        var_c = hgvs.sequencevariant.SequenceVariant(ac=var_n.ac,
+                                                     type="c",
+                                                     posedit=hgvs.posedit.PosEdit(pos_c, edit_c))
         if self.replace_reference:
             self._replace_reference(var_c)
         if self.add_gene_symbol:
@@ -436,15 +455,16 @@ class VariantMapper(object):
 
         # For c. variants, we need coords on underlying sequences
         if var.type == "c":
-            mapper = self._fetch_AlignmentMapper(
-                tx_ac=var.ac, alt_ac=var.ac, alt_aln_method="transcript")
+            mapper = self._fetch_AlignmentMapper(tx_ac=var.ac,
+                                                 alt_ac=var.ac,
+                                                 alt_aln_method="transcript")
             pos = mapper.c_to_n(var.posedit.pos)
         else:
             pos = var.posedit.pos
 
         seq_start = pos.start.base - 1
         seq_end = pos.end.base
-        
+
         # When strict_bounds is False and an error occurs, return
         # variant as-is
 
@@ -460,8 +480,8 @@ class VariantMapper(object):
 
         edit = var.posedit.edit
         if edit.ref != seq:
-            _logger.debug("Replaced reference sequence in {var} with {seq}".format(
-                var=var, seq=seq))
+            _logger.debug("Replaced reference sequence in {var} with {seq}".format(var=var,
+                                                                                   seq=seq))
             edit.ref = seq
 
         return var
@@ -472,8 +492,10 @@ class VariantMapper(object):
         Get a new AlignmentMapper for the given transcript accession (ac),
         possibly caching the result.
         """
-        return hgvs.alignmentmapper.AlignmentMapper(
-            self.hdp, tx_ac=tx_ac, alt_ac=alt_ac, alt_aln_method=alt_aln_method)
+        return hgvs.alignmentmapper.AlignmentMapper(self.hdp,
+                                                    tx_ac=tx_ac,
+                                                    alt_ac=alt_ac,
+                                                    alt_aln_method=alt_aln_method)
 
     @staticmethod
     def _convert_edit_check_strand(strand, edit_in):
@@ -551,7 +573,7 @@ class VariantMapper(object):
     def _update_gene_symbol(self, var, symbol):
         if not symbol:
             symbol = self.hdp.get_tx_identity_info(var.ac).get("hgnc", None)
-        var.gene = symbol            
+        var.gene = symbol
         return var
 
 

--- a/hgvs/variantmapper.py
+++ b/hgvs/variantmapper.py
@@ -21,7 +21,8 @@ import hgvs.utils.altseqbuilder as altseqbuilder
 import hgvs.sequencevariant
 import hgvs.validator
 
-from hgvs.exceptions import HGVSDataNotAvailableError, HGVSUnsupportedOperationError, HGVSInvalidVariantError
+from hgvs.exceptions import HGVSDataNotAvailableError, HGVSUnsupportedOperationError, HGVSInvalidVariantError, \
+    HGVSInvalidIntervalError
 from hgvs.decorators.lru_cache import lru_cache
 from hgvs.enums import PrevalidationLevel
 from hgvs.utils.reftranscriptdata import RefTranscriptData
@@ -166,10 +167,13 @@ class VariantMapper(object):
                 pos_n.end.base -= 1
                 edit_n.ref = ''
         else:
-            # variant at alignment gap
-            pos_g = mapper.n_to_g(pos_n)
-            edit_n = hgvs.edit.NARefAlt(
-                ref='', alt=self._get_altered_sequence(mapper.strand, pos_g, var_g))
+            try:
+                # variant at alignment gap
+                pos_g = mapper.n_to_g(pos_n)
+                edit_n = hgvs.edit.NARefAlt(
+                    ref='', alt=self._get_altered_sequence(mapper.strand, pos_g, var_g))
+            except IndexError:
+                raise HGVSInvalidIntervalError("Variant is at alignment gap.")
         pos_n.uncertain = var_g.posedit.pos.uncertain
         var_n = hgvs.sequencevariant.SequenceVariant(
             ac=tx_ac, type="n", posedit=hgvs.posedit.PosEdit(pos_n, edit_n))
@@ -209,10 +213,13 @@ class VariantMapper(object):
                 pos_g.end.base -= 1
                 edit_g.ref = ''
         else:
-            # variant at alignment gap
-            pos_n = mapper.g_to_n(pos_g)
-            edit_g = hgvs.edit.NARefAlt(
-                ref='', alt=self._get_altered_sequence(mapper.strand, pos_n, var_n))
+            try:
+                # variant at alignment gap
+                pos_n = mapper.g_to_n(pos_g)
+                edit_g = hgvs.edit.NARefAlt(
+                    ref='', alt=self._get_altered_sequence(mapper.strand, pos_n, var_n))
+            except IndexError:
+                raise HGVSInvalidIntervalError("Variant is at alignment gap.")
         pos_g.uncertain = var_n.posedit.pos.uncertain
         var_g = hgvs.sequencevariant.SequenceVariant(
             ac=alt_ac, type="g", posedit=hgvs.posedit.PosEdit(pos_g, edit_g))
@@ -251,10 +258,13 @@ class VariantMapper(object):
                 pos_c.end.base -= 1
                 edit_c.ref = ''
         else:
-            # variant at alignment gap
-            pos_g = mapper.c_to_g(pos_c)
-            edit_c = hgvs.edit.NARefAlt(
-                ref='', alt=self._get_altered_sequence(mapper.strand, pos_g, var_g))
+            try:
+                # variant at alignment gap
+                pos_g = mapper.c_to_g(pos_c)
+                edit_c = hgvs.edit.NARefAlt(
+                    ref='', alt=self._get_altered_sequence(mapper.strand, pos_g, var_g))
+            except IndexError:
+                raise HGVSInvalidIntervalError("Variant is at alignment gap.")
         pos_c.uncertain = var_g.posedit.pos.uncertain
         var_c = hgvs.sequencevariant.SequenceVariant(
             ac=tx_ac, type="c", posedit=hgvs.posedit.PosEdit(pos_c, edit_c))
@@ -292,13 +302,16 @@ class VariantMapper(object):
                 pos_g.end.base -= 1
                 edit_g.ref = ''
         else:
-            # variant at alignment gap
-            var_n = copy.deepcopy(var_c)
-            var_n.posedit.pos = mapper.c_to_n(var_c.posedit.pos)
-            var_n.type = 'n'
-            pos_n = mapper.g_to_n(pos_g)
-            edit_g = hgvs.edit.NARefAlt(
-                ref='', alt=self._get_altered_sequence(mapper.strand, pos_n, var_n))
+            try:
+                # variant at alignment gap
+                var_n = copy.deepcopy(var_c)
+                var_n.posedit.pos = mapper.c_to_n(var_c.posedit.pos)
+                var_n.type = 'n'
+                pos_n = mapper.g_to_n(pos_g)
+                edit_g = hgvs.edit.NARefAlt(
+                    ref='', alt=self._get_altered_sequence(mapper.strand, pos_n, var_n))
+            except IndexError:
+                raise HGVSInvalidIntervalError("Variant is at alignment gap.")
         pos_g.uncertain = var_c.posedit.pos.uncertain
         var_g = hgvs.sequencevariant.SequenceVariant(
             ac=alt_ac, type="g", posedit=hgvs.posedit.PosEdit(pos_g, edit_g))

--- a/hgvs/variantmapper.py
+++ b/hgvs/variantmapper.py
@@ -167,13 +167,10 @@ class VariantMapper(object):
                 pos_n.end.base -= 1
                 edit_n.ref = ''
         else:
-            try:
-                # variant at alignment gap
-                pos_g = mapper.n_to_g(pos_n)
-                edit_n = hgvs.edit.NARefAlt(
-                    ref='', alt=self._get_altered_sequence(mapper.strand, pos_g, var_g))
-            except IndexError:
-                raise HGVSInvalidIntervalError("Variant is at alignment gap.")
+            # variant at alignment gap
+            pos_g = mapper.n_to_g(pos_n)
+            edit_n = hgvs.edit.NARefAlt(
+                ref='', alt=self._get_altered_sequence(mapper.strand, pos_g, var_g))
         pos_n.uncertain = var_g.posedit.pos.uncertain
         var_n = hgvs.sequencevariant.SequenceVariant(
             ac=tx_ac, type="n", posedit=hgvs.posedit.PosEdit(pos_n, edit_n))
@@ -213,13 +210,10 @@ class VariantMapper(object):
                 pos_g.end.base -= 1
                 edit_g.ref = ''
         else:
-            try:
-                # variant at alignment gap
-                pos_n = mapper.g_to_n(pos_g)
-                edit_g = hgvs.edit.NARefAlt(
-                    ref='', alt=self._get_altered_sequence(mapper.strand, pos_n, var_n))
-            except IndexError:
-                raise HGVSInvalidIntervalError("Variant is at alignment gap.")
+            # variant at alignment gap
+            pos_n = mapper.g_to_n(pos_g)
+            edit_g = hgvs.edit.NARefAlt(
+                ref='', alt=self._get_altered_sequence(mapper.strand, pos_n, var_n))
         pos_g.uncertain = var_n.posedit.pos.uncertain
         var_g = hgvs.sequencevariant.SequenceVariant(
             ac=alt_ac, type="g", posedit=hgvs.posedit.PosEdit(pos_g, edit_g))
@@ -258,13 +252,10 @@ class VariantMapper(object):
                 pos_c.end.base -= 1
                 edit_c.ref = ''
         else:
-            try:
-                # variant at alignment gap
-                pos_g = mapper.c_to_g(pos_c)
-                edit_c = hgvs.edit.NARefAlt(
-                    ref='', alt=self._get_altered_sequence(mapper.strand, pos_g, var_g))
-            except IndexError:
-                raise HGVSInvalidIntervalError("Variant is at alignment gap.")
+            # variant at alignment gap
+            pos_g = mapper.c_to_g(pos_c)
+            edit_c = hgvs.edit.NARefAlt(
+                ref='', alt=self._get_altered_sequence(mapper.strand, pos_g, var_g))
         pos_c.uncertain = var_g.posedit.pos.uncertain
         var_c = hgvs.sequencevariant.SequenceVariant(
             ac=tx_ac, type="c", posedit=hgvs.posedit.PosEdit(pos_c, edit_c))
@@ -302,16 +293,13 @@ class VariantMapper(object):
                 pos_g.end.base -= 1
                 edit_g.ref = ''
         else:
-            try:
-                # variant at alignment gap
-                var_n = copy.deepcopy(var_c)
-                var_n.posedit.pos = mapper.c_to_n(var_c.posedit.pos)
-                var_n.type = 'n'
-                pos_n = mapper.g_to_n(pos_g)
-                edit_g = hgvs.edit.NARefAlt(
-                    ref='', alt=self._get_altered_sequence(mapper.strand, pos_n, var_n))
-            except IndexError:
-                raise HGVSInvalidIntervalError("Variant is at alignment gap.")
+            # variant at alignment gap
+            var_n = copy.deepcopy(var_c)
+            var_n.posedit.pos = mapper.c_to_n(var_c.posedit.pos)
+            var_n.type = 'n'
+            pos_n = mapper.g_to_n(pos_g)
+            edit_g = hgvs.edit.NARefAlt(
+                ref='', alt=self._get_altered_sequence(mapper.strand, pos_n, var_n))
         pos_g.uncertain = var_c.posedit.pos.uncertain
         var_g = hgvs.sequencevariant.SequenceVariant(
             ac=alt_ac, type="g", posedit=hgvs.posedit.PosEdit(pos_g, edit_g))
@@ -533,24 +521,27 @@ class VariantMapper(object):
         pos_end = var.posedit.pos.end.base - interval.start.base + 1
         edit = var.posedit.edit
 
-        if edit.type == 'sub':
-            seq[pos_start] = edit.alt
-        elif edit.type == 'del':
-            del seq[pos_start:pos_end]
-        elif edit.type == 'ins':
-            seq.insert(pos_start + 1, edit.alt)
-        elif edit.type == 'delins':
-            del seq[pos_start:pos_end]
-            seq.insert(pos_start, edit.alt)
-        elif edit.type == 'dup':
-            seq.insert(pos_end, ''.join(seq[pos_start:pos_end]))
-        elif edit.type == 'inv':
-            seq[pos_start:pos_end] = list(reverse_complement(''.join(seq[pos_start:pos_end])))
-        elif edit.type == 'identity':
-            pass
-        else:
-            raise HGVSUnsupportedOperationError(
-                "Getting altered sequence for {type} is unsupported".format(type=edit.type))
+        try:
+            if edit.type == 'sub':
+                seq[pos_start] = edit.alt
+            elif edit.type == 'del':
+                del seq[pos_start:pos_end]
+            elif edit.type == 'ins':
+                seq.insert(pos_start + 1, edit.alt)
+            elif edit.type == 'delins':
+                del seq[pos_start:pos_end]
+                seq.insert(pos_start, edit.alt)
+            elif edit.type == 'dup':
+                seq.insert(pos_end, ''.join(seq[pos_start:pos_end]))
+            elif edit.type == 'inv':
+                seq[pos_start:pos_end] = list(reverse_complement(''.join(seq[pos_start:pos_end])))
+            elif edit.type == 'identity':
+                pass
+            else:
+                raise HGVSUnsupportedOperationError(
+                    "Getting altered sequence for {type} is unsupported".format(type=edit.type))
+        except IndexError:
+            raise HGVSInvalidIntervalError("Specified index does not exist within sequence.")
 
         seq = ''.join(seq)
         if strand == -1:

--- a/tests/issues/test_606.py
+++ b/tests/issues/test_606.py
@@ -1,0 +1,42 @@
+import unittest
+
+from hgvs.exceptions import HGVSInvalidIntervalError
+import hgvs
+
+
+class TestIssue606(unittest.TestCase):
+
+    def test_606(self):
+        """https://github.com/biocommons/hgvs/issues/606"""
+
+        from hgvs.easy import am37, parser
+
+        """
+            Occasionally, an IndexError is thrown by the _get_altered_sequence method. This seems to occur
+            when there is either inconsistent data for a transcript in UTA or an invalid variant input.
+            There could be other root causes, but these are two that we have observed and are illustrated in the 
+            examples below.
+            
+            Example 1 (NC_000001.10:g.16890441C>G):
+            Transcript NM_017940.4 has inconsistent data. 25 exons in the 'transcript' alignment to itself, 
+            but 28 exons in the 'splign' alignment to the reference sequence.  
+            Ends up with an index error in _get_altered_sequence.
+    
+            Example 2 (NM_001291722.1:c.283-3C>T):
+            This is invalid input -- according to the transcript in UTA, exon 5 starts at position 286 of the transcript,
+            not position 283. Ends up with an index error in _get_altered_sequence.
+        """
+
+        # Example 1
+        hgvs.global_config.mapping.strict_bounds = False
+        hgvs_g = 'NC_000001.10:g.16890441C>G'
+        var_g = parser.parse_hgvs_variant(hgvs_g)
+        with self.assertRaises(HGVSInvalidIntervalError):
+            var_c = am37.g_to_c(var_g, 'NM_017940.4')
+        hgvs.global_config.mapping.strict_bounds = True
+
+        # Example 2
+        hgvs_c = 'NM_001291722.1:c.283-3C>T'
+        var_c = parser.parse_hgvs_variant(hgvs_c)
+        with self.assertRaises(HGVSInvalidIntervalError):
+            var_g = am37.c_to_g(var_c)

--- a/tests/issues/test_606.py
+++ b/tests/issues/test_606.py
@@ -5,12 +5,10 @@ import hgvs
 
 
 class TestIssue606(unittest.TestCase):
-
     def test_606(self):
         """https://github.com/biocommons/hgvs/issues/606"""
 
         from hgvs.easy import am37, parser
-
         """
             Occasionally, an IndexError is thrown by the _get_altered_sequence method. This seems to occur
             when there is either inconsistent data for a transcript in UTA or an invalid variant input.

--- a/tests/issues/test_606.py
+++ b/tests/issues/test_606.py
@@ -6,24 +6,25 @@ import hgvs
 
 class TestIssue606(unittest.TestCase):
     def test_606(self):
-        """https://github.com/biocommons/hgvs/issues/606"""
-
-        from hgvs.easy import am37, parser
         """
+            https://github.com/biocommons/hgvs/issues/606
+
             Occasionally, an IndexError is thrown by the _get_altered_sequence method. This seems to occur
             when there is either inconsistent data for a transcript in UTA or an invalid variant input.
-            There could be other root causes, but these are two that we have observed and are illustrated in the 
+            There could be other root causes, but these are two that we have observed and are illustrated in the
             examples below.
-            
+
             Example 1 (NC_000001.10:g.16890441C>G):
-            Transcript NM_017940.4 has inconsistent data. 25 exons in the 'transcript' alignment to itself, 
-            but 28 exons in the 'splign' alignment to the reference sequence.  
+            Transcript NM_017940.4 has inconsistent data. 25 exons in the 'transcript' alignment to itself,
+            but 28 exons in the 'splign' alignment to the reference sequence.
             Ends up with an index error in _get_altered_sequence.
-    
+
             Example 2 (NM_001291722.1:c.283-3C>T):
             This is invalid input -- according to the transcript in UTA, exon 5 starts at position 286 of the transcript,
             not position 283. Ends up with an index error in _get_altered_sequence.
         """
+
+        from hgvs.easy import am37, parser
 
         # Example 1
         hgvs.global_config.mapping.strict_bounds = False


### PR DESCRIPTION
Hi Reece, 

I tried adding unit tests in test_hgvs_variantmapper.py for the scenarios described in issue 606. However, I couldn't add them because of the cache that was being used. I was unable to open the cache-py3.hdp file. Would you be able to help me with this? I'd like to add a couple of tests to confirm that the correct exception is being thrown.

Thanks!
Kaylee