### PR TITLE
Fix for python 3.8 open file warning

### DIFF
--- a/hgvs/parser.py
+++ b/hgvs/parser.py
@@ -93,12 +93,13 @@ class Parser(object):
 
     def __init__(self, grammar_fn=__default_grammar_fn, expose_all_rules=False):
         self._grammar_fn = grammar_fn
-        self._grammar = parsley.makeGrammar(
-            open(grammar_fn, "r").read(), {
-                "hgvs": hgvs,
-                "bioutils": bioutils,
-                "copy": copy
-            })
+        with open(grammar_fn, "r") as grammar_file:
+            self._grammar = parsley.makeGrammar(
+                grammar_file.read(), {
+                    "hgvs": hgvs,
+                    "bioutils": bioutils,
+                    "copy": copy
+                })
         self._logger = logging.getLogger(__name__)
         self._expose_rule_functions(expose_all_rules)
 


### PR DESCRIPTION
This pull request fixes the following warning

`/usr/local/lib/python3.8/site-packages/hgvs/parser.py:97: ResourceWarning: unclosed file <_io.TextIOWrapper name='/usr/local/lib/python3.8/site-packages/hgvs/_data/hgvs.pymeta' mode='r' encoding='UTF-8'>`