### PR TITLE
Switch to psycopg2 from wheel-only psycopg2-binary

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(license="Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)",
           "configparser>=3.3.0",
           "ipython",
           "parsley",
-          "psycopg2-binary",
+          "psycopg2",
           "six",
       ],
       setup_requires=[


### PR DESCRIPTION
This closes https://github.com/biocommons/hgvs/issues/623

Per the authors of the `psycopg2` package, `psycopg2-binary` "is meant
for beginners to start playing with Python and PostgreSQL without the
need to meet the build requirements."

However, it's preferable to depend on `psycopg2` for production software.

------

See [issue 623](https://github.com/biocommons/hgvs/issues/623) (or the commit in this PR) for more context.