### PR TITLE
Improve uta pooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,17 +71,20 @@ bdist bdist_egg bdist_wheel build sdist install: %:
 #=> test: execute tests
 #=> test-code: test code (including embedded doctests)
 #=> test-docs: test example code in docs
+#=> stest: test a specific test or set of tests, also useful using ipdb
 #=> test-/tag/ -- run tests marked with /tag/
 # TODO: rationalize tags
 # find tests -name \*.py | xargs perl -ln0e 'while (m/@pytest.mark.(\w+)/g) {print $1 if not $seen{$1}++}'  | sort
 # => extra fx issues mapping models normalization parametrize pnd quick regression validation
-.PHONY: test test-code test-docs
+.PHONY: test test-code test-docs stest
 test:
 	python setup.py pytest
 test-code:
 	python setup.py pytest --addopts="${TEST_DIRS}"
 test-docs:
 	python setup.py pytest --addopts="${DOC_TESTS}"
+stest:
+	python setup.py pytest --addopts="-vvv -s -k ${t}"
 test-%:
 	python setup.py pytest --addopts="-m '$*' ${TEST_DIRS}"
 

--- a/hgvs/dataproviders/uta.py
+++ b/hgvs/dataproviders/uta.py
@@ -623,8 +623,9 @@ class UTA_postgresql(UTABase):
                 _logger.warning(
                     "Lost connection to {url}; attempting reconnect".format(url=self.url))
                 if self.pooling:
-                    self._pool.closeall()
-                self._connect()
+                    self._pool.putconn(conn)
+                else:
+                    self._connect()
                 _logger.warning("Reconnected to {url}".format(url=self.url))
 
             n_tries_rem -= 1

--- a/hgvs/dataproviders/uta.py
+++ b/hgvs/dataproviders/uta.py
@@ -624,9 +624,12 @@ class UTA_postgresql(UTABase):
                     "Lost connection to {url}; attempting reconnect".format(url=self.url))
                 if self.pooling:
                     self._pool.putconn(conn)
+                    _logger.warning(
+                        "Put away pool connection from {url}".format(url=self.url)
+                    )
                 else:
                     self._connect()
-                _logger.warning("Reconnected to {url}".format(url=self.url))
+                    _logger.warning("Reconnected to {url}".format(url=self.url))
 
             n_tries_rem -= 1
 

--- a/hgvs/parser.py
+++ b/hgvs/parser.py
@@ -29,7 +29,7 @@ import hgvs.sequencevariant
 
 
 class Parser(object):
-    """Provides comprehensive parsing of HGVS varaint strings (*i.e.*,
+    """Provides comprehensive parsing of HGVS variant strings (*i.e.*,
     variants represented according to the Human Genome Variation
     Society recommendations) into Python representations.  The class
     wraps a Parsing Expression Grammar, exposing rules of that grammar


### PR DESCRIPTION
We've recently had some issues while using hgvs. Sometimes when UTA receives an update (or it experiences some issue) it closes all connections and this causes some of our applications to experience `psycopg2.pool.PoolError`. 

Looking into it, we realized this portion of the code closes the connections when `self.pooling` and then it tries to connect again, this is essentially what is causing the PoolError.

So if `self.pooling` we just update the pool connections (as the snippet above does) and if not we reconnect to the UTA database. 

We've also tested this locally with our applications and the error stopped showing up. 



To be more specific, here's the source code for psycopg2 https://github.com/psycopg/psycopg2/blob/master/lib/pool.py

The first thing it does when either getting a conn or updating the conn is to check whether the pool is closed (which we are currently doing in `psycopg2.OperationalError` in our `_get_cursor` method

```
if self.closed:
            raise PoolError("connection pool is closed")
```