### PR TITLE
Go back to py36

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,13 +75,13 @@ build: %:
 test:
 	pytest
 test-code:
-	pytest --addopts="${TEST_DIRS}"
+	pytest ${TEST_DIRS}
 test-docs:
-	pytest --addopts="${DOC_TESTS}"
+	pytest ${DOC_TESTS}
 stest:
-	pytest --addopts="-vvv -s -k ${t}"
+	pytest -vvv -s -k ${t}
 test-%:
-	pytest --addopts="-m '$*' ${TEST_DIRS}"
+	pytest -m '$*' ${TEST_DIRS}
 
 #=> test-learn: build test data cache
 #=> test-relearn: destroy and rebuild test data cache

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 description = "HGVS Parser, Formatter, Mapper, Validator"
 readme = "README.rst"
 license = { file="LICENSE.txt" }
-requires-python = ">=3.8"
+requires-python = ">=3.6"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",


### PR DESCRIPTION
Moving from 1.5.2 to 1.5.3 python was bumped from 3.6 to [3.8+](https://github.com/biocommons/hgvs/pull/646/files#:~:text=requires%2Dpython%20%3D%20%22%3E%3D3.8%22), was this a necessary change? We have a lot of repo's that use hgvs and are still on 3.6.x

cc @reece 

---

Also fixed the Makefile for pytest, since now we don't run `python setup.py pytest`, and raw `pytest` doesn't have the `--adopts` arg