### PR TITLE
modernize: Python version support, CI/CD, & build

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,7 +14,7 @@ jobs:
   #     - name: Set up Python
   #       uses: actions/setup-python@v4
   #       with:
-  #         python-version: "3.10"
+  #         python-version: "3.11"
   #         cache: "pip"
   #         cache-dependency-path: "**/setup.cfg"
 
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3
@@ -75,7 +75,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           cache: pip
           cache-dependency-path: "**/setup.cfg"
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,9 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.11"
 
 sphinx:
    configuration: docs/conf.py

--- a/.style.yapf
+++ b/.style.yapf
@@ -1,6 +1,0 @@
-[style]
-based_on_style = pep8
-column_limit = 100
-spaces_before_comment = 4
-split_before_logical_operator = True
-split_before_named_assigns = True

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,10 @@ sudo: required
 language: python
 
 python:
-  - '3.7'
   - '3.8'
   - '3.9'
+  - '3.10'
+  - '3.11'
 
 cache: pip
 
@@ -26,7 +27,7 @@ stages:
 jobs:
   include:
     - stage: deploy
-      python: 3.9
+      python: 3.11
       install: skip
       script: skip
       deploy:

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,35 +1,35 @@
-Contributors are listed in the Mercurial change logs.  From the
-command line:
+Contributors are listed in the Git commit log. From the command line:
 
 $ git shortlog -sne
-  1049	Reece Hart <reecehart@gmail.com>
-   151	Meng <wangm0855@gmail.com>
-   116	Rudy Rico <rudy.rico@invitae.com>
-    39	Vincent Fusaro <vincent.fusaro@invitae.com>
-    20	Meng Wang <wangm0855@gmail.com>
-    19	Lucas Wiman <lucas.wiman@gmail.com>
-     9	Piotr Kaleta <piotrek.kaleta@gmail.com>
-     5	Alexandre Fedtsov <shmumer@users.noreply.github.com>
-     3	Dimitris Iliopoulos <diliopoulos@pacificbiosciences.com>
-     3	Kevin Jacobs <jacobs@bioinformed.com>
-     2	Alan Rubin <alan.rubin@wehi.edu.au>
-     2	Emanuel Langit <emanuel.langit@fastmail.fm>
-     2	Jai Pradeesh <jaipradeesh@gmail.com>
-     2	Jake Peacock <james.hoke.peacock@gmail.com>
-     1	Andreas Prlic <36012160+andreas-invitae@users.noreply.github.com>
-     1	Andreas Prlic <andreas.prlic@gmail.com>
-     1	Andy McMurry (AndyMC) <andymc@apache.org>
-     1	Clayton Wheeler <cwheeler@genomenon.com>
-     1	Daniel Saxton <dsaxton@protonmail.com>
-     1	John Kern <kern3020@gmail.com>
-     1	Keith Callenberg <keithcallenberg@users.noreply.github.com>
-     1	Kevin McCurdy <khmccurdy@aol.com>
-     1	Lawrence Lee <lawrence.lee@invitae.com>
-     1	Liang Chen <chenliangomc@users.noreply.github.com>
-     1	Naomi Fox <naomi.fox@gmail.com>
-     1	Rudolph Rico <rudy.rico@invitae.com>
-     1	Sandeep Narayanaswami <scoffes@gmail.com>
-     1	Timothy Laurent <timothy.laurent@invitae.com>
+  1096  Reece Hart <reecehart@gmail.com>
+   151  Meng <wangm0855@gmail.com>
+   116  Rudy Rico <rudy.rico@invitae.com>
+    39  Vincent Fusaro <vincent.fusaro@invitae.com>
+    20  Meng Wang <wangm0855@gmail.com>
+    19  Lucas Wiman <lucas.wiman@gmail.com>
+    19  Reece Hart <reece@biocommons.org>
+     9  Piotr Kaleta <piotrek.kaleta@gmail.com>
+     5  Alexandre Fedtsov <shmumer@users.noreply.github.com>
+     3  Dimitris Iliopoulos <diliopoulos@pacificbiosciences.com>
+     3  Kevin Jacobs <jacobs@bioinformed.com>
+     3  jdasilva-invitae <jhonatan.dasilva@invitae.com>
+     2  Alan Rubin <alan.rubin@wehi.edu.au>
+     2  Andreas Prlic <andreas.prlic@invitae.com>
+     2  Douglas Myers-Turnbull <dmyersturnbull@gmail.com>
+     2  Emanuel Langit <emanuel.langit@fastmail.fm>
+     2  Jai Pradeesh <jaipradeesh@gmail.com>
+     2  Jake Peacock <james.hoke.peacock@gmail.com>
+     1  Alex Henrie <alexhenrie24@gmail.com>
+     1  Andreas Prlic <36012160+andreas-invitae@users.noreply.github.com>
+     1  Andreas Prlic <andreas.prlic@gmail.com>
+     1  Andy McMurry (AndyMC) <andymc@apache.org>
+     1  Ben Robinson <bmrobin9823@gmail.com>
+     1  Caitlin Gong <clgong@vassar.edu>
+     1  Clayton Wheeler <cwheeler@genomenon.com>
+     1  Daniel Saxton <dsaxton@protonmail.com>
+     1  David Cain <davidjosephcain@gmail.com>
+     1  Jeff Tratner <jeffrey.tratner@gmail.com>
+     1  John Kern <kern3020@gmail.com>
 
 
 Additional non-coding contributors are:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,1 +1,1 @@
-Changelog is in docs/changelog/ and available online at http://hgvs.readthedocs.io/en/latest/changelog/index.html
+Changelog is in docs/changelog/ and available online at https://hgvs.readthedocs.io/en/latest/changelog/index.html

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 *hgvs* - manipulate biological sequence variants according to Human Genome Variation Society recommendations
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-**Important:** biocommons packages require Python 3.6+.
+**Important:** biocommons packages require Python 3.8+.
 `More
 <https://groups.google.com/forum/#!topic/hgvs-discuss/iLUzjzoD-28>`__
 

--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,7 @@ Important Notes
   listed there.  Please report any issues you find.
 * **Use a pip package specification to stay within minor releases.**
   For example, ``hgvs>=1.5,<1.6``. `hgvs` uses `Semantic Versioning
-  <http://semver.org/>`__.
+  <https://semver.org/>`__.
 
 
 Examples
@@ -89,7 +89,7 @@ easy.
   
 
 See `Installation instructions
-<http://hgvs.readthedocs.org/en/stable/installation.html>`__ for
+<https://hgvs.readthedocs.org/en/stable/installation.html>`__ for
 details, including instructions for installing `Universal Transcript
 Archive (UTA) <https://github.com/biocommons/uta/>`__ and `SeqRepo
 <https://github.com/biocommons/biocommons.seqrepo/>`__ locally.
@@ -245,7 +245,7 @@ veriants into a single representation.
 
 
 There are `more examples in the documentation
-<http://hgvs.readthedocs.org/en/stable/examples.html>`_.
+<https://hgvs.readthedocs.org/en/stable/examples.html>`_.
 
 
 Citing hgvs (the package)
@@ -257,7 +257,7 @@ Citing hgvs (the package)
 
 | **A Python Package for Parsing, Validating, Mapping, and Formatting Sequence Variants Using HGVS Nomenclature.**
 | Hart RK, Rico R, Hare E, Garcia J, Westbrook J, Fusaro VA.
-| *Bioinformatics*. 2014 Sep 30. `PubMed <http://www.ncbi.nlm.nih.gov/pubmed/25273102>`__ | `Open Access PDF <http://bioinformatics.oxfordjournals.org/content/31/2/268.full.pdf>`__
+| *Bioinformatics*. 2014 Sep 30. `PubMed <https://www.ncbi.nlm.nih.gov/pubmed/25273102>`__ | `Open Access PDF <https://bioinformatics.oxfordjournals.org/content/31/2/268.full.pdf>`__
 
 
 Contributing
@@ -265,7 +265,7 @@ Contributing
 
 The hgvs package is intended to be a community project.  Please see
 `Contributing
-<http://hgvs.readthedocs.org/en/stable/contributing.html>`__ to get
+<https://hgvs.readthedocs.org/en/stable/contributing.html>`__ to get
 started in submitting source code, tests, or documentation.  Thanks
 for getting involved!
 
@@ -279,14 +279,14 @@ Other packages that manipulate HGVS variants:
 * `Mutalyzer <https://mutalyzer.nl/>`__
 
 
-.. _docs: http://hgvs.readthedocs.org/
-.. _Variation Nomenclature: http://varnomen.hgvs.org/
+.. _docs: https://hgvs.readthedocs.org/
+.. _Variation Nomenclature: https://varnomen.hgvs.org/
 
 .. |getting_help| image:: https://img.shields.io/badge/!-help%20me-red.svg
    :target: https://hgvs.readthedocs.io/en/stable/getting_help.html
 
 .. |rtd| image:: https://img.shields.io/badge/docs-readthedocs-green.svg
-   :target: http://hgvs.readthedocs.io/
+   :target: https://hgvs.readthedocs.io/
 
 .. |changelog| image:: https://img.shields.io/badge/docs-changelog-green.svg
    :target: https://hgvs.readthedocs.io/en/stable/changelog/

--- a/docs/changelog/0.4/0.4.0.rst
+++ b/docs/changelog/0.4/0.4.0.rst
@@ -14,7 +14,7 @@ $$$$$$$$$$$$$$$$$
 * `#244 <https://github.com/biocommons/hgvs/issues/244/>`_: Removed cache_transcripts argument from VariantMapper. This argument was deprecated in 0.3.0 and is now obsolete. Dataproviders are now expected to cache data.
 * `#246 <https://github.com/biocommons/hgvs/issues/246/>`_: Remove hgvsX_to_hgvsY methods. These methods were deprecated in 0.3.0 and are now obsolete.
 * `#247 <https://github.com/biocommons/hgvs/issues/247/>`_: Dup and Repeat "seq" instance variable renamed to "ref" for consistency.
-* EasyVariantMapper, Normalizer, and Validator now fetch sequence data at runtime, which may raise performance and privacy concerns. Users may wish to read `Privacy Issues <http://hgvs.readthedocs.org/en/default/privacy.html>`_ in the documentation.
+* EasyVariantMapper, Normalizer, and Validator now fetch sequence data at runtime, which may raise performance and privacy concerns. Users may wish to read `Privacy Issues <https://hgvs.readthedocs.org/en/default/privacy.html>`_ in the documentation.
 
 
 Deprecations

--- a/docs/changelog/0.4/0.4.0.rst
+++ b/docs/changelog/0.4/0.4.0.rst
@@ -65,7 +65,7 @@ Internal and Developer Changes
 $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
 
 * `#263 <https://github.com/biocommons/hgvs/issues/263/>`_: Trying out a new tag-based changelog mechanism for 0.4.0 and 0.4 series.
-* All code will be mercilously reformmated with yapf occasionally using .style.yapf
+* All code will be mercilously reformmated with black
 * Build and upload wheel packages (in addition to existing eggs and tarballs)
 * Docs significantly overhauled and moved to readthedocs.org with automatic webhook-based building
 * Enable users to set application_name when connecting [`BROKEN: 835ac7771909 <https://github.com/biocommons/hgvs/commit/835ac7771909>`_]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,7 +44,7 @@ html_favicon = 'static/favicon.ico'
 html_logo = 'static/hgvs-logo.png'
 html_static_path = ['static']
 html_title = '{project} {release}'.format(project=project, release=release)
-intersphinx_mapping = {'http://docs.python.org/': None, }
+intersphinx_mapping = {'https://docs.python.org/': None, }
 master_doc = 'index'
 pygments_style = 'sphinx'
 source_suffix = '.rst'
@@ -64,7 +64,7 @@ rst_epilog = open(rst_epilog_fn).read()
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -35,15 +35,13 @@ Highlights
   close to it).
 
 * Abide by current `code style`_.  Use ``make reformat`` to reformat all
-  code with `yapf`_ prior to submitting a PR.
+  code with `black`_ prior to submitting a PR.
 
 * Email the `hgvs-discuss`_ mailing list if you have questions.
 
 * Test your code with ``make test`` before you submit a PR.
 
-* Currently, only Python 2.7 is supported. Support for Python 3.5 is
-  slated for the next release
-  (`#190 <https://github.com/biocommons/hgvs/issues/190/>`__).
+* Currently, only Python 3.8+ is supported.
 
 
 A Quick Contribution Example
@@ -202,7 +200,7 @@ changes::
   spaces_before_comment = 4
   split_before_named_assigns = True
 
-These code conventions are uniformly enforce by yapf_.  The entire code
+These code conventions are uniformly enforce by black_.  The entire code
 base is periodically automatically reformatted for consistency.
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dynamic = ["version"]
 [project.urls]
 "Homepage" = "https://github.com/biocommons/hgvs"
 "Bug Tracker" = "https://github.com/biocommons/hgvs/issues"
+"Release Notes" = "https://hgvs.readthedocs.io/en/latest/changelog/index.html"
 
 [project.scripts]
 "hgvs-shell" = "hgvs.shell:shell"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 description = "HGVS Parser, Formatter, Mapper, Validator"
 readme = "README.rst"
 license = { file="LICENSE.txt" }
-requires-python = ">=3.6"
+requires-python = ">=3.8"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
@@ -14,11 +14,12 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
     "Topic :: Scientific/Engineering :: Medical Science Apps."
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,7 @@ universal = 1
 [build_sphinx]
 all_files  = 1
 
-# http://pep8.readthedocs.org/en/latest/intro.html#error-codes
+# https://pep8.readthedocs.org/en/latest/intro.html#error-codes
 [flake8]
 max-line-length = 120
 exclude = tests/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,6 @@ install_requires =
     biocommons.seqrepo >= 0.6.5
     bioutils >= 0.4.0,<1.0
     configparser >= 3.3.0
-    ipython
     parsley
     psycopg2
     six
@@ -34,11 +33,9 @@ hgvs =
 
 [options.extras_require]
 dev =
-    black
+    black >= 23
     flake8
-    ipython
     isort
-    jupyter
     pytest >= 5.3
     pytest-cov >= 2.8
     pytest-vcr
@@ -49,7 +46,6 @@ dev =
     sphinxcontrib-fulltoc >= 1.1
     tox
     vcrpy
-    yapf
 
 
 [aliases]

--- a/src/hgvs/__init__.py
+++ b/src/hgvs/__init__.py
@@ -98,7 +98,7 @@ _logger.info("hgvs " + __version__ + "; released: " + str(_is_released_version))
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/hgvs/alignmentmapper.py
+++ b/src/hgvs/alignmentmapper.py
@@ -297,7 +297,7 @@ class AlignmentMapper(object):
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/hgvs/assemblymapper.py
+++ b/src/hgvs/assemblymapper.py
@@ -252,7 +252,7 @@ class AssemblyMapper(VariantMapper):
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/hgvs/dataproviders/interface.py
+++ b/src/hgvs/dataproviders/interface.py
@@ -38,7 +38,7 @@ class Interface(six.with_metaclass(abc.ABCMeta, object)):
     indirect) of this class.
 
     .. _`Universal Transcript Archive (UTA)`: https://github.com/biocommons/uta
-    .. _Invitae: http://invitae.com/
+    .. _Invitae: https://invitae.com/
     """
 
     def interface_version(self):
@@ -185,7 +185,7 @@ class Interface(six.with_metaclass(abc.ABCMeta, object)):
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/hgvs/dataproviders/seqfetcher.py
+++ b/src/hgvs/dataproviders/seqfetcher.py
@@ -74,7 +74,7 @@ class SeqFetcher(object):
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/hgvs/dataproviders/uta.py
+++ b/src/hgvs/dataproviders/uta.py
@@ -693,7 +693,7 @@ if __name__ == "__main__":
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/hgvs/decorators/lru_cache.py
+++ b/src/hgvs/decorators/lru_cache.py
@@ -5,7 +5,7 @@ checking, __wrapped__, and cache_info). Includes Py3.3 optimizations
 for better memory utilization, fewer dependencies, and fewer dict
 lookups.
 
-http://code.activestate.com/recipes/578078-py26-and-py30-backport-of-python-33s-lru-cache/
+https://code.activestate.com/recipes/578078-py26-and-py30-backport-of-python-33s-lru-cache/
 
 Added persistence capability
 
@@ -93,7 +93,7 @@ def lru_cache(maxsize=100, typed=False, mode=None, cache=None):
     f.cache_info().  Clear the cache and statistics with f.cache_clear().
     Access the underlying function with f.__wrapped__.
 
-    See:  http://en.wikipedia.org/wiki/Cache_algorithms#Least_Recently_Used
+    See:  https://en.wikipedia.org/wiki/Cache_algorithms#Least_Recently_Used
 
 
     :param mode: cache run mode

--- a/src/hgvs/easy.py
+++ b/src/hgvs/easy.py
@@ -72,7 +72,7 @@ get_relevant_transcripts = am38.relevant_transcripts
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/hgvs/edit.py
+++ b/src/hgvs/edit.py
@@ -612,7 +612,7 @@ if __name__ == "__main__":
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/hgvs/exceptions.py
+++ b/src/hgvs/exceptions.py
@@ -60,7 +60,7 @@ class HGVSVerifyFailedError(HGVSError):
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/hgvs/hgvsposition.py
+++ b/src/hgvs/hgvsposition.py
@@ -44,7 +44,7 @@ class HGVSPosition(object):
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/hgvs/intervalmapper.py
+++ b/src/hgvs/intervalmapper.py
@@ -216,7 +216,7 @@ def cigar_to_intervalpairs(cigar):
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/hgvs/location.py
+++ b/src/hgvs/location.py
@@ -388,7 +388,7 @@ class BaseOffsetInterval(Interval):
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/hgvs/normalizer.py
+++ b/src/hgvs/normalizer.py
@@ -427,7 +427,7 @@ if __name__ == "__main__":
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/hgvs/parser.py
+++ b/src/hgvs/parser.py
@@ -151,7 +151,7 @@ class Parser(object):
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/hgvs/posedit.py
+++ b/src/hgvs/posedit.py
@@ -118,7 +118,7 @@ class PosEdit(object):
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/hgvs/sequencevariant.py
+++ b/src/hgvs/sequencevariant.py
@@ -95,7 +95,7 @@ class SequenceVariant(object):
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/hgvs/shell.py
+++ b/src/hgvs/shell.py
@@ -71,7 +71,7 @@ def shell():
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/hgvs/transcriptmapper.py
+++ b/src/hgvs/transcriptmapper.py
@@ -310,7 +310,7 @@ def _hgvs_coord_to_ci(s, e):
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/hgvs/utils/PersistentDict.py
+++ b/src/hgvs/utils/PersistentDict.py
@@ -42,7 +42,7 @@ class PersistentDict(dict):
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/hgvs/utils/__init__.py
+++ b/src/hgvs/utils/__init__.py
@@ -47,7 +47,7 @@ def build_tx_cigar(exons, strand):
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/hgvs/utils/altseq_to_hgvsp.py
+++ b/src/hgvs/utils/altseq_to_hgvsp.py
@@ -356,7 +356,7 @@ class AltSeqToHgvsp(object):
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/hgvs/utils/altseqbuilder.py
+++ b/src/hgvs/utils/altseqbuilder.py
@@ -373,7 +373,7 @@ class AltSeqBuilder(object):
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/hgvs/utils/norm.py
+++ b/src/hgvs/utils/norm.py
@@ -171,7 +171,7 @@ def normalize_alleles(ref, start, stop, alleles, bound, ref_step, left, shuffle=
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/hgvs/utils/orderedenum.py
+++ b/src/hgvs/utils/orderedenum.py
@@ -30,7 +30,7 @@ class OrderedEnum(Enum):
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/hgvs/validator.py
+++ b/src/hgvs/validator.py
@@ -180,7 +180,7 @@ class ExtrinsicValidator:
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/hgvs/variantmapper.py
+++ b/src/hgvs/variantmapper.py
@@ -549,7 +549,7 @@ class VariantMapper(object):
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/support/crosschecker.py
+++ b/tests/support/crosschecker.py
@@ -100,7 +100,7 @@ class CrossChecker(object):
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/support/mock_input_source.py
+++ b/tests/support/mock_input_source.py
@@ -97,7 +97,7 @@ if __name__ == "__main__":
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/test_clinvar.py
+++ b/tests/test_clinvar.py
@@ -77,7 +77,7 @@ if __name__ == "__main__":
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/test_hgvs_alignmentmapper.py
+++ b/tests/test_hgvs_alignmentmapper.py
@@ -339,7 +339,7 @@ if __name__ == "__main__":
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/test_hgvs_assemblymapper.py
+++ b/tests/test_hgvs_assemblymapper.py
@@ -393,7 +393,7 @@ if __name__ == "__main__":
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/test_hgvs_dataproviders_uta.py
+++ b/tests/test_hgvs_dataproviders_uta.py
@@ -173,7 +173,7 @@ if __name__ == "__main__":
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/test_hgvs_edit.py
+++ b/tests/test_hgvs_edit.py
@@ -114,7 +114,7 @@ if __name__ == "__main__":
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/test_hgvs_grammar.py
+++ b/tests/test_hgvs_grammar.py
@@ -81,7 +81,7 @@ if __name__ == "__main__":
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/test_hgvs_grammar_full.py
+++ b/tests/test_hgvs_grammar_full.py
@@ -125,7 +125,7 @@ if __name__ == "__main__":
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/test_hgvs_hgvsposition.py
+++ b/tests/test_hgvs_hgvsposition.py
@@ -35,7 +35,7 @@ if __name__ == "__main__":
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/test_hgvs_location.py
+++ b/tests/test_hgvs_location.py
@@ -210,7 +210,7 @@ if __name__ == "__main__":
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/test_hgvs_normalizer.py
+++ b/tests/test_hgvs_normalizer.py
@@ -354,7 +354,7 @@ if __name__ == "__main__":
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/test_hgvs_parser.py
+++ b/tests/test_hgvs_parser.py
@@ -78,7 +78,7 @@ if __name__ == "__main__":
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/test_hgvs_posedit.py
+++ b/tests/test_hgvs_posedit.py
@@ -33,7 +33,7 @@ if __name__ == "__main__":
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/test_hgvs_projector.py
+++ b/tests/test_hgvs_projector.py
@@ -29,7 +29,7 @@ class TestHgvsProjector(unittest.TestCase):
 
     @pytest.mark.quick
     def test_rs201430561(self):
-        # rs201430561 http://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=201430561
+        # rs201430561 https://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?rs=201430561
         hgvs_c = ["NM_001197320.1:c.281C>T", "NM_021960.4:c.740C>T", "NM_182763.2:c.688+403C>T"]
         var_c = [self.hp.parse_hgvs_variant(h) for h in hgvs_c]
         self.tst_forward_and_backward(var_c[0], var_c[1])

--- a/tests/test_hgvs_sequencevariant.py
+++ b/tests/test_hgvs_sequencevariant.py
@@ -105,7 +105,7 @@ if __name__ == "__main__":
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/test_hgvs_validator.py
+++ b/tests/test_hgvs_validator.py
@@ -186,7 +186,7 @@ if __name__ == "__main__":
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/test_hgvs_variantmapper.py
+++ b/tests/test_hgvs_variantmapper.py
@@ -128,7 +128,7 @@ if __name__ == "__main__":
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/test_hgvs_variantmapper_cp_altseqbuilder.py
+++ b/tests/test_hgvs_variantmapper_cp_altseqbuilder.py
@@ -141,7 +141,7 @@ if __name__ == "__main__":
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/test_hgvs_variantmapper_cp_real.py
+++ b/tests/test_hgvs_variantmapper_cp_real.py
@@ -107,7 +107,7 @@ if __name__ == "__main__":
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/test_hgvs_variantmapper_cp_sanity.py
+++ b/tests/test_hgvs_variantmapper_cp_sanity.py
@@ -182,7 +182,7 @@ class TestHgvsCToP(unittest.TestCase):
         self._run_conversion(hgvsc, hgvsp_expected)
 
     # See recommendations re p.? (p.Met1?) at:
-    # http://varnomen.hgvs.org/recommendations/protein/variant/substitution/
+    # https://varnomen.hgvs.org/recommendations/protein/variant/substitution/
     def test_substitution_removes_start_codon(self):
         hgvsc = "NM_999999.1:c.1A>G"
         hgvsp_expected = "MOCK:p.Met1?"
@@ -271,7 +271,7 @@ if __name__ == "__main__":
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/test_hgvs_variantmapper_gcp.py
+++ b/tests/test_hgvs_variantmapper_gcp.py
@@ -194,7 +194,7 @@ if __name__ == "__main__":
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/test_hgvs_variantmapper_near_discrepancies.py
+++ b/tests/test_hgvs_variantmapper_near_discrepancies.py
@@ -51,7 +51,7 @@ def test_projection_near_discrepancies(variant, expected, description):
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/tests/test_seqfetcher_initialization.py
+++ b/tests/test_seqfetcher_initialization.py
@@ -21,12 +21,12 @@ def test_seqfetcher_initialized_with_seqrepo_dir(mock_path_exists, monkeypatch):
 
 
 def test_seqfetcher_initialized_with_seqrepo_url(monkeypatch):
-    monkeypatch.setenv("HGVS_SEQREPO_URL", "http://localhost:5000/seqrepo")
+    monkeypatch.setenv("HGVS_SEQREPO_URL", "https://localhost:5000/seqrepo")
     sf = SeqFetcher()
     assert isinstance(sf.sr, SeqRepoRESTDataProxy)
     # the URL should be versioned automatically for us
-    assert sf.sr.base_url == "http://localhost:5000/seqrepo/1/"
-    assert sf.source == "SeqRepo REST (http://localhost:5000/seqrepo)"
+    assert sf.sr.base_url == "https://localhost:5000/seqrepo/1/"
+    assert sf.source == "SeqRepo REST (https://localhost:5000/seqrepo)"
 
 
 def test_seqfetcher_initialized_with_public_seqrepo_sources(monkeypatch):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py39,py310
+envlist = py38,py39,py310,py311
 
 [testenv]
 setenv =


### PR DESCRIPTION
- [x] Test and document Python 3.11 support. Also drop past-EOL 3.6 and 3.7.
- [x] Fix small issues in docs
- [ ] Re-enable CI: I noticed the Travis tests no longer run. (I'm guessing when they changed to .com.) Would GitHub Actions be ok for this? I can add a new test workflow.
- [ ] pre-commit? I found that having tools like black run on commit can clean up diffs. If the devs like the idea, I'll add it.
- [ ] replace [https://github.com/readthedocs/sphinx_rtd_theme](rtd_theme)? It's now poorly maintained, and [furo](https://github.com/pradyunsg/furo) may be a good replacement.