### PR TITLE
Add format GitHub workflow

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,14 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: psf/black@stable
+        with:
+          options: "--check --verbose"
+          src: "./src"
+          version: "~= 23.0"

--- a/src/hgvs/__init__.py
+++ b/src/hgvs/__init__.py
@@ -49,8 +49,7 @@ BaseOffsetPosition(base=1582, offset=0, datum=Datum.CDS_START, uncertain=False)
 
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
 import re

--- a/src/hgvs/alignmentmapper.py
+++ b/src/hgvs/alignmentmapper.py
@@ -27,8 +27,7 @@ The AlignmentMapper class is at the heart of mapping between aligned sequences.
 #
 
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from bioutils.coordinates import strand_int_to_pm
 from six.moves import range
@@ -36,8 +35,7 @@ from six.moves import range
 import hgvs.location
 from hgvs import global_config
 from hgvs.enums import Datum
-from hgvs.exceptions import (HGVSDataNotAvailableError, HGVSError,
-                             HGVSInvalidIntervalError, HGVSUsageError)
+from hgvs.exceptions import HGVSDataNotAvailableError, HGVSError, HGVSInvalidIntervalError, HGVSUsageError
 from hgvs.utils import build_tx_cigar
 from hgvs.utils.cigarmapper import CIGARMapper
 
@@ -88,7 +86,6 @@ class AlignmentMapper(object):
         self.alt_aln_method = alt_aln_method
 
         if self.alt_aln_method != "transcript":
-
             tx_info = hdp.get_tx_info(self.tx_ac, self.alt_ac, self.alt_aln_method)
             if tx_info is None:
                 raise HGVSDataNotAvailableError(
@@ -126,7 +123,6 @@ class AlignmentMapper(object):
             self.tgt_len = self.cigarmapper.tgt_len
 
         else:
-
             # this covers the identity cases n <-> c
             tx_identity_info = hdp.get_tx_identity_info(self.tx_ac)
             if tx_identity_info is None:

--- a/src/hgvs/assemblymapper.py
+++ b/src/hgvs/assemblymapper.py
@@ -1,15 +1,12 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
 
 import hgvs
 import hgvs.normalizer
-from hgvs.exceptions import (HGVSDataNotAvailableError, HGVSError,
-                             HGVSInvalidVariantError,
-                             HGVSUnsupportedOperationError)
+from hgvs.exceptions import HGVSDataNotAvailableError, HGVSError, HGVSInvalidVariantError, HGVSUnsupportedOperationError
 from hgvs.variantmapper import VariantMapper
 
 _logger = logging.getLogger(__name__)
@@ -57,7 +54,7 @@ class AssemblyMapper(VariantMapper):
         replace_reference=hgvs.global_config.mapping.replace_reference,
         add_gene_symbol=hgvs.global_config.mapping.add_gene_symbol,
         *args,
-        **kwargs
+        **kwargs,
     ):
         """
         :param object hdp: instance of hgvs.dataprovider subclass
@@ -78,7 +75,7 @@ class AssemblyMapper(VariantMapper):
             prevalidation_level=prevalidation_level,
             add_gene_symbol=add_gene_symbol,
             *args,
-            **kwargs
+            **kwargs,
         )
         self.assembly_name = assembly_name
         self.alt_aln_method = alt_aln_method

--- a/src/hgvs/config.py
+++ b/src/hgvs/config.py
@@ -27,8 +27,7 @@ for str, int, and boolean.
 
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
 import re

--- a/src/hgvs/dataproviders/interface.py
+++ b/src/hgvs/dataproviders/interface.py
@@ -3,8 +3,7 @@
 
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import abc
 import os

--- a/src/hgvs/dataproviders/ncbi.py
+++ b/src/hgvs/dataproviders/ncbi.py
@@ -311,7 +311,6 @@ class NCBI_postgresql(NCBIBase):
         n_tries_rem = n_retries + 1
         while n_tries_rem > 0:
             try:
-
                 conn = self._pool.getconn() if self.pooling else self._conn
 
                 # autocommit=True obviates closing explicitly
@@ -330,7 +329,6 @@ class NCBI_postgresql(NCBIBase):
                 break
 
             except psycopg2.OperationalError:
-
                 _logger.warning("Lost connection to {url}; attempting reconnect".format(url=self.url))
                 if self.pooling:
                     self._pool.closeall()
@@ -340,7 +338,6 @@ class NCBI_postgresql(NCBIBase):
             n_tries_rem -= 1
 
         else:
-
             # N.B. Probably never reached
             raise HGVSError("Permanently lost connection to {url} ({n} retries)".format(url=self.url, n=n_retries))
 

--- a/src/hgvs/dataproviders/seqfetcher.py
+++ b/src/hgvs/dataproviders/seqfetcher.py
@@ -3,8 +3,7 @@
 
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
 import os

--- a/src/hgvs/dataproviders/uta.py
+++ b/src/hgvs/dataproviders/uta.py
@@ -4,8 +4,7 @@
 
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import contextlib
 import inspect
@@ -580,7 +579,6 @@ class UTA_postgresql(UTABase):
         n_tries_rem = n_retries + 1
         while n_tries_rem > 0:
             try:
-
                 conn = self._pool.getconn() if self.pooling else self._conn
 
                 # autocommit=True obviates closing explicitly
@@ -604,7 +602,6 @@ class UTA_postgresql(UTABase):
                 break
 
             except psycopg2.OperationalError:
-
                 _logger.warning("Lost connection to {url}; attempting reconnect".format(url=self.url))
                 if self.pooling:
                     self._pool.putconn(conn)
@@ -616,7 +613,6 @@ class UTA_postgresql(UTABase):
             n_tries_rem -= 1
 
         else:
-
             # N.B. Probably never reached
             raise HGVSError("Permanently lost connection to {url} ({n} retries)".format(url=self.url, n=n_retries))
 

--- a/src/hgvs/decorators/deprecated.py
+++ b/src/hgvs/decorators/deprecated.py
@@ -4,8 +4,7 @@ marks a function as deprecated.
 
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import collections
 import warnings

--- a/src/hgvs/decorators/lru_cache.py
+++ b/src/hgvs/decorators/lru_cache.py
@@ -11,8 +11,7 @@ Added persistence capability
 
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from collections import namedtuple
 from functools import update_wrapper

--- a/src/hgvs/edit.py
+++ b/src/hgvs/edit.py
@@ -9,8 +9,7 @@ location).
 
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import attr
 import six

--- a/src/hgvs/exceptions.py
+++ b/src/hgvs/exceptions.py
@@ -3,8 +3,7 @@
 
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 
 class HGVSError(Exception):

--- a/src/hgvs/hgvsposition.py
+++ b/src/hgvs/hgvsposition.py
@@ -3,8 +3,7 @@
 
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import attr
 

--- a/src/hgvs/intervalmapper.py
+++ b/src/hgvs/intervalmapper.py
@@ -42,8 +42,7 @@ Currently, this code matches an interval <start_i,end_i> using the maximal
 start_i and minimal end_i.
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
 import re

--- a/src/hgvs/location.py
+++ b/src/hgvs/location.py
@@ -15,8 +15,7 @@ Classes:
   * :class:`Interval` -- an interval of Positions
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from functools import total_ordering
 
@@ -25,8 +24,7 @@ from bioutils.sequences import aa1_to_aa3
 
 import hgvs
 from hgvs.enums import Datum, ValidationLevel
-from hgvs.exceptions import (HGVSInvalidIntervalError,
-                             HGVSUnsupportedOperationError)
+from hgvs.exceptions import HGVSInvalidIntervalError, HGVSUnsupportedOperationError
 
 
 @attr.s(slots=True, repr=False, cmp=False)

--- a/src/hgvs/normalizer.py
+++ b/src/hgvs/normalizer.py
@@ -2,8 +2,7 @@
 """hgvs.normalizer
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import copy
 import logging
@@ -13,9 +12,7 @@ from bioutils.sequences import reverse_complement
 import hgvs
 import hgvs.validator
 import hgvs.variantmapper
-from hgvs.exceptions import (HGVSDataNotAvailableError,
-                             HGVSInvalidVariantError,
-                             HGVSUnsupportedOperationError)
+from hgvs.exceptions import HGVSDataNotAvailableError, HGVSInvalidVariantError, HGVSUnsupportedOperationError
 from hgvs.utils.norm import normalize_alleles
 
 _logger = logging.getLogger(__name__)

--- a/src/hgvs/parser.py
+++ b/src/hgvs/parser.py
@@ -4,8 +4,7 @@ components, such as intronic-offset coordiates
 
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import copy
 import logging
@@ -17,6 +16,7 @@ import parsley
 from pkg_resources import resource_filename
 
 import hgvs.edit
+
 # The following imports are referenced by fully-qualified name in the
 # hgvs grammar.
 import hgvs.enums

--- a/src/hgvs/posedit.py
+++ b/src/hgvs/posedit.py
@@ -3,8 +3,7 @@
 
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import attr
 

--- a/src/hgvs/projector.py
+++ b/src/hgvs/projector.py
@@ -4,8 +4,7 @@ via a common reference sequence.
 
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import copy
 

--- a/src/hgvs/sequencevariant.py
+++ b/src/hgvs/sequencevariant.py
@@ -3,8 +3,7 @@
 
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import re
 

--- a/src/hgvs/shell.py
+++ b/src/hgvs/shell.py
@@ -2,8 +2,7 @@
 """start IPython shell with hgvs initialized. Intended to be used for
 experimenting, debugging, and generating bug reports."""
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
 import os
@@ -46,12 +45,42 @@ def shell():
     logging.basicConfig(level=os.environ.get("HGVS_LOGGING_LEVEL", logging.WARNING))
 
     from hgvs.easy import (  # noqa: F401; instances; functionalized methods
-        __version__, am37, am38, c_to_g, c_to_n, c_to_p, g_to_c, g_to_n,
-        g_to_t, get_relevant_transcripts, global_config, hdp,
-        hgvs_assembly_mapper_37, hgvs_assembly_mapper_38, hgvs_data_provider,
-        hgvs_normalizer, hgvs_parser, hgvs_validator, hgvs_variant_mapper, hn,
-        hp, hv, n_to_c, n_to_g, normalize, normalizer, parse, parser,
-        projector, t_to_g, t_to_p, validate, validator, variant_mapper, vm)
+        __version__,
+        am37,
+        am38,
+        c_to_g,
+        c_to_n,
+        c_to_p,
+        g_to_c,
+        g_to_n,
+        g_to_t,
+        get_relevant_transcripts,
+        global_config,
+        hdp,
+        hgvs_assembly_mapper_37,
+        hgvs_assembly_mapper_38,
+        hgvs_data_provider,
+        hgvs_normalizer,
+        hgvs_parser,
+        hgvs_validator,
+        hgvs_variant_mapper,
+        hn,
+        hp,
+        hv,
+        n_to_c,
+        n_to_g,
+        normalize,
+        normalizer,
+        parse,
+        parser,
+        projector,
+        t_to_g,
+        t_to_p,
+        validate,
+        validator,
+        variant_mapper,
+        vm,
+    )
     from hgvs.utils.context import variant_context_w_alignment  # noqa
 
     IPython.embed(

--- a/src/hgvs/transcriptmapper.py
+++ b/src/hgvs/transcriptmapper.py
@@ -4,8 +4,7 @@ genomic (g), non-coding (n), cds (c), and protein (p) coordinates.
 
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
 
@@ -15,8 +14,7 @@ from six.moves import range
 import hgvs.intervalmapper
 import hgvs.location
 from hgvs.enums import Datum
-from hgvs.exceptions import (HGVSDataNotAvailableError, HGVSError,
-                             HGVSUsageError)
+from hgvs.exceptions import HGVSDataNotAvailableError, HGVSError, HGVSUsageError
 from hgvs.utils import build_tx_cigar
 
 _logger = logging.getLogger(__name__)

--- a/src/hgvs/utils/__init__.py
+++ b/src/hgvs/utils/__init__.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import itertools
 import re

--- a/src/hgvs/utils/altseq_to_hgvsp.py
+++ b/src/hgvs/utils/altseq_to_hgvsp.py
@@ -5,8 +5,7 @@ Used in hgvsc to hgvsp conversion.
 
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from six.moves import range
 
@@ -59,7 +58,6 @@ class AltSeqToHgvsp(object):
         variants = []
 
         if not self._is_ambiguous and len(self._alt_seq) > 0:
-
             do_delins = True
             if self._ref_seq == self._alt_seq:
                 # Silent p. variant
@@ -248,7 +246,6 @@ class AltSeqToHgvsp(object):
                         alt = None
 
             elif len(deletion) == 0:  # insertion OR duplication OR extension
-
                 is_dup, dup_start = self._check_if_ins_is_dup(start, insertion)
 
                 if is_dup:  # duplication

--- a/src/hgvs/utils/altseqbuilder.py
+++ b/src/hgvs/utils/altseqbuilder.py
@@ -6,8 +6,7 @@ Used in hgvsc to hgvsp conversion.
 
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
 import math
@@ -83,7 +82,6 @@ class AltTranscriptData(object):
 
 
 class AltSeqBuilder(object):
-
     EXON = "exon"
     INTRON = "intron"
     F_UTR = "five utr"

--- a/src/hgvs/utils/context.py
+++ b/src/hgvs/utils/context.py
@@ -23,8 +23,7 @@ NM_000399.3  c      902 <                                                    <  
 
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import re
 

--- a/src/hgvs/utils/norm.py
+++ b/src/hgvs/utils/norm.py
@@ -5,8 +5,7 @@ https://github.com/bioinformed/vgraph
 
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from collections import namedtuple
 

--- a/src/hgvs/utils/orderedenum.py
+++ b/src/hgvs/utils/orderedenum.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from enum import Enum
 

--- a/src/hgvs/validator.py
+++ b/src/hgvs/validator.py
@@ -3,8 +3,7 @@
 
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
 
@@ -13,8 +12,7 @@ import hgvs.edit
 import hgvs.parser
 import hgvs.variantmapper
 from hgvs.enums import Datum, ValidationLevel
-from hgvs.exceptions import (HGVSInvalidVariantError,
-                             HGVSUnsupportedOperationError)
+from hgvs.exceptions import HGVSInvalidVariantError, HGVSUnsupportedOperationError
 
 SEQ_ERROR_MSG = "Variant reference ({var_ref_seq}) does not agree with reference sequence ({ref_seq})"
 CDS_BOUND_ERROR_MSG = "Variant is outside CDS bounds (CDS length : {cds_length})"

--- a/src/hgvs/variantmapper.py
+++ b/src/hgvs/variantmapper.py
@@ -3,8 +3,7 @@
 
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import copy
 import logging
@@ -23,9 +22,7 @@ import hgvs.utils.altseqbuilder as altseqbuilder
 import hgvs.validator
 from hgvs.decorators.lru_cache import lru_cache
 from hgvs.enums import PrevalidationLevel
-from hgvs.exceptions import (HGVSDataNotAvailableError,
-                             HGVSInvalidVariantError,
-                             HGVSUnsupportedOperationError)
+from hgvs.exceptions import HGVSDataNotAvailableError, HGVSInvalidVariantError, HGVSUnsupportedOperationError
 from hgvs.utils.reftranscriptdata import RefTranscriptData
 
 _logger = logging.getLogger(__name__)


### PR DESCRIPTION
Add `black` format check Github workflow to pushes and pull requests. Also formats code using `black` in order to pass check. Most changes look to be differences in output between `black` and `isort`, another PR follows to reconfigure `isort` output.

For more information:
https://black.readthedocs.io/en/stable/integrations/github_actions.html

See also #413 