### PR TITLE
Add isort profile configuration to match black

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,9 @@ line-length = 120
 # https://github.com/PyCQA/flake8/issues/234#issuecomment-812800832
 # The config in setup.cfg
 
+[tool.isort]
+profile = "black"
+
 [tool.pylint.'MESSAGES CONTROL']
 disable = "R0913"
 


### PR DESCRIPTION
Add isort configuration to allow interoperability with black. Without this they step on each other.

For more information:
https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html
https://pycqa.github.io/isort/docs/configuration/black_compatibility.html

Related:
#413 
#671 