### PR TITLE
Add ruff linter configuration

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,8 @@
+name: Ruff
+on: [push, pull_request]
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: chartboost/ruff-action@v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,3 +110,7 @@ disable = "R0913"
 
 [tool.pylint.format]
 max-line-length = "120"
+
+
+[tool.ruff]
+line-length = 120

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ dev =
     pytest-cov >= 2.8
     pytest-vcr
     restview
+    ruff
     setuptools
     sphinx
     sphinx_rtd_theme


### PR DESCRIPTION
Per @korikuzma's suggestion on #671, this adds a basic `ruff` configuration. This should be merged after the 18 errors are fixed.

Related:
#413 