### PR TITLE
Add inline ignore for line too long errors

### DIFF
--- a/src/hgvs/decorators/lru_cache.py
+++ b/src/hgvs/decorators/lru_cache.py
@@ -104,7 +104,7 @@ def lru_cache(maxsize=100, typed=False, mode=None, cache=None):
         VERIFY: always execute the function; if persistent cache value and returned value are different, raise VerifyFailedError
     :param cache: PersistentDict object or None;
 
-    """
+    """  # noqa: E501
 
     # Users should only access the lru_cache through its public API:
     #       cache_info, cache_clear, and f.__wrapped__

--- a/src/hgvs/location.py
+++ b/src/hgvs/location.py
@@ -194,7 +194,7 @@ class BaseOffsetPosition(object):
                     lhs.base - rhs.base == 1 and rhs.offset > 0 and lhs.offset < 0
                 ):
                     raise HGVSUnsupportedOperationError(
-                        "Cannot compare coordinates in the same intron with one based on end of exon and the other based on start of next exon"
+                        "Cannot compare coordinates in the same intron with one based on end of exon and the other based on start of next exon"  # noqa: E501
                     )
                 else:
                     return lhs.base < rhs.base


### PR DESCRIPTION
Ignore line too long long errors raised by `ruff`.

Unblocks #673 