### PR TITLE
Fix linter complaint about ambiguous variable name

### DIFF
--- a/src/hgvs/utils/context.py
+++ b/src/hgvs/utils/context.py
@@ -167,7 +167,7 @@ def seq_line_fmt(var, span, content, dir=""):
 def pointer_line(var, span):
     s0 = span[0]
     o = var.posedit.pos.start.base - s0
-    l = var.posedit.pos.end.base - var.posedit.pos.start.base + 1
+    l = var.posedit.pos.end.base - var.posedit.pos.start.base + 1  # noqa: E741
     if var.posedit.edit.type == "ins":
         p = " " * o + "><"
     else:


### PR DESCRIPTION
Fixes linter error E741 raised by `ruff`. I don't know why `ruff` wasn't upset by the variable `o`. The variable name `line_length` is only a guess on my part.

Unblocks #673 