### PR TITLE
Remove unused string format argument

### DIFF
--- a/src/hgvs/decorators/lru_cache.py
+++ b/src/hgvs/decorators/lru_cache.py
@@ -40,7 +40,7 @@ class _HashedSeq(list):
         self.hashvalue = hash(tuple(self))
 
     def __repr__(self):
-        return "_HashedSeq({tuple!r})".format(self=self, tuple=tuple(self))
+        return "_HashedSeq({tuple!r})".format(tuple=tuple(self))
 
 
 def _make_key(


### PR DESCRIPTION
Fixes linter error F522 raised by `ruff`.

Unblocks #673 