### PR TITLE
Remove unused variables

### DIFF
--- a/src/hgvs/__init__.py
+++ b/src/hgvs/__init__.py
@@ -78,7 +78,7 @@ try:
     # TODO: match other valid release tags, like .post\d+
     if re.match(r"^\d+\.\d+\.\d+$", __version__) is not None:
         _is_released_version = True
-except pkg_resources.DistributionNotFound as e:
+except pkg_resources.DistributionNotFound:
     warnings.warn("can't get __version__ because %s package isn't installed" % __package__, Warning)
     __version__ = None
 

--- a/src/hgvs/alignmentmapper.py
+++ b/src/hgvs/alignmentmapper.py
@@ -260,9 +260,6 @@ class AlignmentMapper(object):
                     raise HGVSInvalidIntervalError(f"c.{pos} coordinate is out of bounds")
             return hgvs.location.BaseOffsetPosition(base=n, offset=pos.offset, datum=Datum.SEQ_START)
 
-        n_start = pos_c_to_n(c_interval.start)
-        n_end = pos_c_to_n(c_interval.end)
-
         n_interval = hgvs.location.BaseOffsetInterval(
             start=pos_c_to_n(c_interval.start), end=pos_c_to_n(c_interval.end), uncertain=c_interval.uncertain
         )

--- a/src/hgvs/utils/norm.py
+++ b/src/hgvs/utils/norm.py
@@ -116,8 +116,6 @@ def normalize_alleles_right(ref, start, stop, alleles, bound, ref_step, shuffle=
 
     normalized_alleles = namedtuple("shuffled_alleles", "start stop alleles")
 
-    chrom_stop = len(ref)
-
     if len(alleles) < 2:
         return normalized_alleles(start, stop, alleles)
 

--- a/src/hgvs/variantmapper.py
+++ b/src/hgvs/variantmapper.py
@@ -118,7 +118,6 @@ class VariantMapper(object):
         if self._validator:
             self._validator.validate(var_t)
         var_t.fill_ref(self.hdp)
-        mapper = self._fetch_AlignmentMapper(tx_ac=var_t.ac, alt_ac=alt_ac, alt_aln_method=alt_aln_method)
         if var_t.type == "c":
             var_out = VariantMapper.c_to_g(self, var_c=var_t, alt_ac=alt_ac, alt_aln_method=alt_aln_method)
         else:


### PR DESCRIPTION
Fixes linter error F841 raised by `ruff`.

Unblocks #673 