### PR TITLE
Remove unused variables

### DIFF
--- a/tests/issues/test_03xx.py
+++ b/tests/issues/test_03xx.py
@@ -126,7 +126,7 @@ class Test_Issues(unittest.TestCase):
 
         self.am37.in_par_assume = None
         with self.assertRaises(HGVSError):
-            var_g = self.am37.c_to_g(var_c)
+            self.am37.c_to_g(var_c)
 
         self.am37.in_par_assume = "X"
         self.assertEqual(self.am37.c_to_g(var_c).ac, "NC_000023.10")

--- a/tests/issues/test_437.py
+++ b/tests/issues/test_437.py
@@ -100,10 +100,10 @@ class Test437_RMRP(unittest.TestCase):
         # TODO: These exceptions are raised, but with the wrong message
         # use `match=` arg
         with pytest.raises(HGVSInvalidVariantError):
-            s2_g = self.am37.n_to_g(self.s2_n)
+            self.am37.n_to_g(self.s2_n)
 
         with pytest.raises(HGVSInvalidVariantError):
-            e2_g = self.am37.n_to_g(self.e2_n)
+            self.am37.n_to_g(self.e2_n)
 
 
 def test_oob_dup(parser, am37):

--- a/tests/issues/test_602.py
+++ b/tests/issues/test_602.py
@@ -14,10 +14,10 @@ def test_602(parser, am37):
 
     hgvs.global_config.mapping.strict_bounds = True  # default
     with pytest.raises(HGVSInvalidIntervalError):
-        var_c = am37.g_to_c(var_g, "NM_006772.2")
+        am37.g_to_c(var_g, "NM_006772.2")
 
     hgvs.global_config.mapping.strict_bounds = False
-    var_c = am37.g_to_c(var_g, "NM_006772.2")  # No error
+    am37.g_to_c(var_g, "NM_006772.2")  # No error
 
 
 if __name__ == "__main__":

--- a/tests/test_hgvs_edit.py
+++ b/tests/test_hgvs_edit.py
@@ -16,7 +16,7 @@ from hgvs.exceptions import HGVSError
 class Test_Edit(unittest.TestCase):
     def test_NARefAlt_exceptions(self):
         with self.assertRaises(HGVSError):
-            edit = str(hgvs.edit.NARefAlt(None, None))
+            str(hgvs.edit.NARefAlt(None, None))
 
     def test_NARefAlt(self):
         self.assertEqual(hgvs.edit.NARefAlt("A", "A").format(conf={"max_ref_length": None}), "A=")
@@ -87,7 +87,7 @@ class Test_Edit(unittest.TestCase):
 
     def test_Repeat_exceptions(self):
         with self.assertRaises(HGVSError):
-            edit = str(hgvs.edit.Repeat("CAG", 34, 12))
+            str(hgvs.edit.Repeat("CAG", 34, 12))
 
     def test_Inv(self):
         self.assertEqual(str(hgvs.edit.Inv()), "inv")

--- a/tests/test_hgvs_location.py
+++ b/tests/test_hgvs_location.py
@@ -91,7 +91,6 @@ class Test_BaseOffsetPosition(unittest.TestCase):
     def test_baseoffset_subtraction(self):
         v30 = hgvs.location.BaseOffsetPosition(3, 0)
         v50 = hgvs.location.BaseOffsetPosition(5, 0)
-        v52 = hgvs.location.BaseOffsetPosition(5, 2)
         v54 = hgvs.location.BaseOffsetPosition(5, 4)
 
         self.assertEqual(v50 - v30, 2)

--- a/tests/test_hgvs_variantmapper.py
+++ b/tests/test_hgvs_variantmapper.py
@@ -59,7 +59,7 @@ class Test_VariantMapper_Exceptions(unittest.TestCase):
         for key in cases:
             try:
                 func, args = cases[key]
-                var_result = func(*args)
+                func(*args)
                 failures.append(key)
             except hgvs.exceptions.HGVSInvalidVariantError:
                 pass
@@ -70,7 +70,7 @@ class Test_VariantMapper_Exceptions(unittest.TestCase):
         hgvs_g = "NC_000007.13:g.36561662C>T"
         var_g = self.hp.parse_hgvs_variant(hgvs_g)
         with self.assertRaises(hgvs.exceptions.HGVSError):
-            var_p = self.vm.c_to_p(var_g, "NM_999999.1")
+            self.vm.c_to_p(var_g, "NM_999999.1")
 
     def test_undefined_cds(self):
         """Raise exception when requesting mapping to/from c. with non-coding transcript"""
@@ -78,7 +78,6 @@ class Test_VariantMapper_Exceptions(unittest.TestCase):
         hgvs_c = "NR_111984.1:c.44G>A"  # bogus: c. with non-coding tx accession
         var_n = self.hp.parse_hgvs_variant(hgvs_n)
         var_c = self.hp.parse_hgvs_variant(hgvs_c)
-        tx_ac = var_n.ac
 
         with self.assertRaises(hgvs.exceptions.HGVSUsageError):
             var_c = self.vm.n_to_c(var_n)  # n_to_c: transcript is non-coding

--- a/tests/test_hgvs_variantmapper_cp_altseqbuilder.py
+++ b/tests/test_hgvs_variantmapper_cp_altseqbuilder.py
@@ -101,11 +101,10 @@ class TestAltSeqBuilder(unittest.TestCase):
 
     def test_sequence_with_length_that_is_not_divisible_by_3(self):
         hgvsc = "NM_999992.2:c.1del"
-        expected_sequence = "AAAATCAAATGGGGTAGGCCCGGCAGCCAGCTTTATAGAGGAGGCAGTTTCGCC"
         with self.assertRaises(NotImplementedError):
             ac_p = "DUMMY"
             var = self._parser.parse_hgvs_variant(hgvsc)
-            transcript_data = RefTranscriptData(hdp=self._datasource, tx_ac=var.ac, pro_ac=ac_p)
+            RefTranscriptData(hdp=self._datasource, tx_ac=var.ac, pro_ac=ac_p)
 
     # def test_2_substitutions(self):
     #     pass


### PR DESCRIPTION
Fixes linter error F841. Continuation of #681, as I neglected to lint the `tests/` path.

Unblocks #673 