### PR TITLE
Explicitly define test imports

### DIFF
--- a/tests/issues/test_437.py
+++ b/tests/issues/test_437.py
@@ -158,6 +158,6 @@ def test_invitae_examples(parser, am37):
 
 
 if __name__ == "__main__":
-    from hgvs.easy import *
+    from hgvs.easy import am37, parser
 
     test_invitae_examples(parser=parser, am37=am37)


### PR DESCRIPTION
Fixes linter error `F403` by removing `*` import.

For more information: https://www.flake8rules.com/rules/F403.html

Unblocks #673 