### PR TITLE
#689 - undo circular import introduced from linting fix

### DIFF
--- a/src/hgvs/normalizer.py
+++ b/src/hgvs/normalizer.py
@@ -18,7 +18,6 @@ from hgvs.exceptions import (
     HGVSInvalidVariantError,
     HGVSUnsupportedOperationError,
 )
-from hgvs.parser import Parser
 from hgvs.utils.norm import normalize_alleles
 
 _logger = logging.getLogger(__name__)
@@ -416,6 +415,8 @@ class Normalizer(object):
 
 
 if __name__ == "__main__":
+    from hgvs.parser import Parser
+
     hgvsparser = Parser()
     var = hgvsparser.parse_hgvs_variant("NM_001166478.1:c.61delG")
     hdp = connect()


### PR DESCRIPTION
Fix for #689 - cannot import parser due to circular import introduced in #679 - "Fix undefined names"