### PR TITLE
Remove test HTTP network calls

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -97,11 +97,24 @@ A Quick Contribution Example
 
 * Code, code, code!
 
-  You probably want to test code with::
+.. spacer
+
+* Test, test, test
+
+  You can run the tests using make::
 
     $ make test
 
   See `Local UTA`_ and `make`_ for tips on accellerating testing.
+
+  If your tests make network calls you can capture those calls
+  with vcrpy and the pytest-recording plugin::
+
+    $ pytest --record-mode=once tests
+
+  To confirm that network calls are mocked::
+
+    $ pytest --block-network tests
 
 .. spacer
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ dev =
     jupyter
     pytest >= 5.3
     pytest-cov >= 2.8
-    pytest-vcr
+    pytest-recording
     restview
     setuptools
     sphinx

--- a/tests/cassettes/test_hgvs_extras_babelfish/test_hgvs_to_vcf.yaml
+++ b/tests/cassettes/test_hgvs_extras_babelfish/test_hgvs_to_vcf.yaml
@@ -1,0 +1,717 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000006.12&rettype=fasta&seq_start=49949414&seq_stop=49949415&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAEzPUMjKxNLSxNLE0MTXSjDVMEjPzdfoTixIDM1r1ghOaMIyC3Oz01V
+        MNNRcA9yzjC20CswNFEIKMrMTSyqVHAsLk7NTcqp5HIM4eICAAAA//8DAMdKh5hbAAAA
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:38:47 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - D0BD088E3BFC1F95000059CA76DF15C7.1.1.m_5
+      NCBI-SID:
+      - B1A27651152648DF_8588SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=B1A27651152648DF_8588SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:38:47 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000006.12&rettype=fasta&seq_start=49949409&seq_stop=49949410&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAEzPUMjKxNLSxNLEwNLXQjD0EDBIz83X6E4sSAzNa9YITmjCMgtzs9N
+        VTDTUXAPcs4wttArMDRRCCjKzE0sqlRwLC5OzU3KqeRyd+TiAgAAAP//AwD3w5xtWwAAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:38:52 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 939B73A67CF44655000064C54EE87989.1.1.m_5
+      NCBI-SID:
+      - 392D8AA349E8AA92_A602SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=392D8AA349E8AA92_A602SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:38:52 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000006.12&rettype=fasta&seq_start=49949409&seq_stop=49949410&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAEzPUMjKxNLSxNLEwNLXQjD0EDBIz83X6E4sSAzNa9YITmjCMgtzs9N
+        VTDTUXAPcs4wttArMDRRCCjKzE0sqlRwLC5OzU3KqeRyd+TiAgAAAP//AwD3w5xtWwAAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:38:55 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 322C409D773A9D45000050ACDDC290B9.1.1.m_5
+      NCBI-SID:
+      - B2AF9A42AEE54455_D6D3SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=B2AF9A42AEE54455_D6D3SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:38:55 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000006.12&rettype=fasta&seq_start=49949409&seq_stop=49949411&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAEzPUMjKxNLSxNLEwNLXQjD0FDBIz83X6E4sSAzNa9YITmjCMgtzs9N
+        VTDTUXAPcs4wttArMDRRCCjKzE0sqlRwLC5OzU3KqeRyd3Tk4gIAAAD//wMAvn+321wAAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:39:00 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 322C409D773A9D45000052ACE5B62BC9.1.1.m_5
+      NCBI-SID:
+      - 474952FE3B81DE04_8882SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=474952FE3B81DE04_8882SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:39:01 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000006.12&rettype=fasta&seq_start=49949413&seq_stop=49949413&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAEzPUMjKxNLSxNLE0NjXRhDwSM/N1+hOLEgMzWvWCE5owjILc7PTVUw
+        01FwD3LOMLbQKzA0UQgoysxNLKpUcCwuTs1NyqnkcuTiAgAAAP//AwDiKcvrWgAAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:39:04 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 939B73A67CF44655000057C57E228497.1.1.m_5
+      NCBI-SID:
+      - 0111CB37FA57685D_C84ASID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=0111CB37FA57685D_C84ASID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:39:04 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000006.12&rettype=fasta&seq_start=49949414&seq_stop=49949414&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAEzPUMjKxNLSxNLE0MTXRhDwSM/N1+hOLEgMzWvWCE5owjILc7PTVUw
+        01FwD3LOMLbQKwCqCijKzE0sqlRwLC5OzU3KqeRy5OICAAAA//8DADv167RaAAAA
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:39:07 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 939B73A67CF4465500005BC58AF03CB3.1.1.m_5
+      NCBI-SID:
+      - 6A460A736A614E74_8DBASID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=6A460A736A614E74_8DBASID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:39:07 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000006.12&rettype=fasta&seq_start=49949409&seq_stop=49949410&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAEzPUMjKxNLSxNLEwNLXQjD0EDBIz83X6E4sSAzNa9YITmjCMgtzs9N
+        VTDTUXAPcs4wttArMDRRCCjKzE0sqlRwLC5OzU3KqeRyd+TiAgAAAP//AwD3w5xtWwAAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:39:11 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 322C409D773A9D4500002FAD05558A08.1.1.m_5
+      NCBI-SID:
+      - 5323A4BBA72A6DDE_95A4SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=5323A4BBA72A6DDE_95A4SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:39:10 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000006.12&rettype=fasta&seq_start=49949409&seq_stop=49949410&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAEzPUMjKxNLSxNLEwNLXQjD0EDBIz83X6E4sSAzNa9YITmjCMgtzs9N
+        VTDTUXAPcs4wttArMDRRCCjKzE0sqlRwLC5OzU3KqeRyd+TiAgAAAP//AwD3w5xtWwAAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:39:13 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 322C409D773A9D4500003BAD0FBD7ABF.1.1.m_5
+      NCBI-SID:
+      - B1096DE861FC721D_7B9ASID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=B1096DE861FC721D_7B9ASID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:39:13 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000006.12&rettype=fasta&seq_start=49949409&seq_stop=49949410&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAEzPUMjKxNLSxNLEwNLXQjD0EDBIz83X6E4sSAzNa9YITmjCMgtzs9N
+        VTDTUXAPcs4wttArMDRRCCjKzE0sqlRwLC5OzU3KqeRyd+TiAgAAAP//AwD3w5xtWwAAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:39:17 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 322C409D773A9D45000046AD1C0B25CF.1.1.m_5
+      NCBI-SID:
+      - 99974B8D8B46489E_031BSID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=99974B8D8B46489E_031BSID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:39:17 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000006.12&rettype=fasta&seq_start=49949409&seq_stop=49949411&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAEzPUMjKxNLSxNLEwNLXQjD0FDBIz83X6E4sSAzNa9YITmjCMgtzs9N
+        VTDTUXAPcs4wttArMDRRCCjKzE0sqlRwLC5OzU3KqeRyd3Tk4gIAAAD//wMAvn+321wAAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:39:20 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - D0BD088E3BFC1F95000021CAB7356B8B.1.1.m_5
+      NCBI-SID:
+      - FA06FE043A76C083_1F96SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=FA06FE043A76C083_1F96SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:39:20 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000006.12&rettype=fasta&seq_start=49949409&seq_stop=49949411&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAEzPUMjKxNLSxNLEwNLXQjD0FDBIz83X6E4sSAzNa9YITmjCMgtzs9N
+        VTDTUXAPcs4wttArMDRRCCjKzE0sqlRwLC5OzU3KqeRyd3Tk4gIAAAD//wMAvn+321wAAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:39:22 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 322C409D773A9D45000018AD2A55A05F.1.1.m_5
+      NCBI-SID:
+      - F0AD2FFCA143D09B_5ADCSID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=F0AD2FFCA143D09B_5ADCSID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:39:23 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_hgvs_variantmapper/test_add_gene_symbol.yaml
+++ b/tests/cassettes/test_hgvs_variantmapper/test_add_gene_symbol.yaml
@@ -1,0 +1,199 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000007.13&rettype=fasta&seq_start=21940852&seq_stop=21940908&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAACyKwQrCMBBE7/mK/QAtSaOk9SAse1hPIpK7VAm00JiSPfXv3Rbn8JjhzfVOL7sl
+        NM5fWtefbHduj3vpbQe3kgvIsEzpK/AZq04pOUE4AD9p9KFZnIdHnfJQV0CRlN/zapgiRYUSGZGJ
+        o3IDoQomVEW7pf+VGTmyMT8AAAD//wMAgcqFPJIAAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:55:11 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - D0BD088E3BFC1F95000027D342CD3AA1.1.1.m_5
+      NCBI-SID:
+      - 5E15FE75BF75F081_EF40SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=5E15FE75BF75F081_EF40SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:55:12 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NM_003777.3&rettype=fasta&seq_start=13583&seq_stop=13639&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAACzKsQoCMQyA4b1PkVHhlAtBqw5CiJBb7CDdpWjhCrYVDsR7e6u4fMv/H9352vdk
+        rV3TAWmzoxXSlvYw1FxhCs8UywT3ucRUOgjvWmIOjw7GGF4z3MaQCiDC4uR4QFx2kC+OjYoX32iy
+        Mquob34RbkGFW5Jflf+qyurVmA8AAAD//wMAvVGMaZEAAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:55:16 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - D0BD088E3BFC1F9500004ED35B50876A.1.1.m_5
+      NCBI-SID:
+      - FCDA44B12F41665D_36D6SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=FCDA44B12F41665D_36D6SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:55:16 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NM_003777.3&rettype=fasta&seq_start=13639&seq_stop=13639&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLz8403MDA2NzfXM7YyNDYzttQFkwoe+bn5CsWJBZmpecUKKZV5qZl5OgqJFfl5
+        qbmJOToKGamJZZUKyRmJmXkKhoYKGi5+jh6Ghpo6CrlBfo5c7lxcAAAAAP//AwDevCrBWQAAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:55:19 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - D0BD088E3BFC1F95000050D37376716A.1.1.m_5
+      NCBI-SID:
+      - A6329ACD128DFC2C_9424SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=A6329ACD128DFC2C_9424SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:55:20 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/issues/cassettes/test_437/Test437_RMRP.test_terminii.yaml
+++ b/tests/issues/cassettes/test_437/Test437_RMRP.test_terminii.yaml
@@ -1,0 +1,724 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NR_003051.3&rettype=fasta&seq_start=1&seq_stop=1&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAByLQQrCMBBF9znFLBVUEoobF4Iru7FILiAxHXWgmR8y9f627v7jvX8e4sP7zh/D
+        oTuFfaAeBWSpCqtRHC6UUSqUdSa8qMiM/IGOTdL017Uhs5nom1hHNHlCv3niZEybeIv37W7pVlr2
+        +nBX534AAAD//wMA27fHp3YAAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:55:47 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - D0BD088E3BFC1F95000022D3CD94A9CB.1.1.m_5
+      NCBI-SID:
+      - 816BFD558AF2E77C_1ED5SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=816BFD558AF2E77C_1ED5SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:55:48 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000009.11&rettype=fasta&seq_start=35658015&seq_stop=35658015&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAFLPUNDK2NTM1MLA0NTXRhDwSM/N1+hOLEgMzWvWCE5owjILc7PTVWw
+        1FFwD3LOMDbXKzA0VggoysxNLKpUcCwuTs1NyqnkcubiAgAAAP//AwDnkv4LWgAAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:55:59 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 939B73A67CF44655000031D008438DF0.1.1.m_5
+      NCBI-SID:
+      - 57CDCAEEBE85A047_BCF6SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=57CDCAEEBE85A047_BCF6SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:55:59 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000009.11&rettype=fasta&seq_start=35658015&seq_stop=35658035&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAFLPUNDK2NTM1MLA0NTXQjD2FTBIz83X6E4sSAzNa9YITmjCMgtzs9N
+        VbDUUXAPcs4wNtcrMDRWCCjKzE0sqlRwLC5OzU3KqeRydnR2D3F2DnF2dHcOAZJA2tGdiwsAAAD/
+        /wMA2inJj24AAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:56:06 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - D0BD088E3BFC1F9500003BD3FB7E6395.1.1.m_5
+      NCBI-SID:
+      - BAEC923936C84EBA_ECCBSID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=BAEC923936C84EBA_ECCBSID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:56:07 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NR_003051.3&rettype=fasta&seq_start=1&seq_stop=21&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAByLsQ4CIRBEe75iS03UgBcbCxNCsTZeDKE3yKGSHLsEzv+Xs5p5mTeX0T6kHORJ
+        HYaz2h8VXDkzNF9SpAZ21BA4F6ZIC/ALclo4fJimmvz8n0vlEFtL9IZIE9f0ZPqGOfoWYWNv9r7d
+        dW+l3teHQHTOoEPjUGtE09NpIX4AAAD//wMAmzUuDIsAAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:56:10 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 939B73A67CF4465500005BD02F9E6F31.1.1.m_5
+      NCBI-SID:
+      - A7FC3CC9C3116CBC_6986SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=A7FC3CC9C3116CBC_6986SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:56:09 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NR_003051.3&rettype=fasta&seq_start=268&seq_stop=268&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzC4o3MDA2MDXUM7YyMrPQBWIFj/zcfIXixILM1LxihSA/R4Xk/NyC/LzUvBKF
+        /DSF3MyS/OSM/LyUoszEHLB0QVF+cmpxcWZeukJqXkp+UWZSfl5pck5qYnGqgkaQb1CApg5QHYgH
+        ZIN0cIVwcQEAAAD//wMA6f+Xa3oAAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:56:14 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 939B73A67CF44655000059D03F053C86.1.1.m_5
+      NCBI-SID:
+      - 21BFEDD5A6E9D8E0_DF31SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=21BFEDD5A6E9D8E0_DF31SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:56:14 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000009.11&rettype=fasta&seq_start=35657748&seq_stop=35657748&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAFLPUNDK2NTM1NzcxMLXRhDwSM/N1+hOLEgMzWvWCE5owjILc7PTVWw
+        1FFwD3LOMDbXKzA0VggoysxNLKpUcCwuTs1NyqnkcuTiAgAAAP//AwDcgGfzWgAAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:56:19 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 939B73A67CF44655000061D05724E9C2.1.1.m_5
+      NCBI-SID:
+      - D9CFDA6116DF73A5_55DASID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=D9CFDA6116DF73A5_55DASID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:56:19 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000009.11&rettype=fasta&seq_start=35657748&seq_stop=35657768&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAFLPUNDK2NTM1NzcxMLXQjDzELBIz83X6E4sSAzNa9YITmjCMgtzs9N
+        VbDUUXAPcs4wNtcrMDRWCCjKzE0sqlRwLC5OzU3KqeRydHZ0d3Z2B8IQd0d3R0cQ6czFBQAAAP//
+        AwAibL8ebgAAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:56:33 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 322C409D773A9D45000047B8AD5C8012.1.1.m_5
+      NCBI-SID:
+      - 8483AF755DE09F70_1A61SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=8483AF755DE09F70_1A61SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:56:33 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000009.11&rettype=fasta&seq_start=35658016&seq_stop=35658016&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAFLPUNDK2NTM1MLA0MzXRhDwSM/N1+hOLEgMzWvWCE5owjILc7PTVWw
+        1FFwD3LOMDbXKzA0VggoysxNLKpUcCwuTs1NyqnkcuTiAgAAAP//AwCcUQEoWgAAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:57:16 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 322C409D773A9D4500004AB921165AFA.1.1.m_5
+      NCBI-SID:
+      - 5EF13E1280FBD31F_D647SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=5EF13E1280FBD31F_D647SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:57:17 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000009.11&rettype=fasta&seq_start=35658016&seq_stop=35658036&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAFLPUNDK2NTM1MLA0MzXQjD2EzBIz83X6E4sSAzNa9YITmjCMgtzs9N
+        VbDUUXAPcs4wNtcrMDRWCCjKzE0sqlRwLC5OzU3KqeRydHYPcXYOcXZ0dw4BkkDa0T2EiwsAAAD/
+        /wMAFTiFWG4AAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:57:20 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 322C409D773A9D4500003EB932F1C519.1.1.m_5
+      NCBI-SID:
+      - 2AD8A768E914CC00_9A57SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=2AD8A768E914CC00_9A57SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:57:21 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000009.11&rettype=fasta&seq_start=35657747&seq_stop=35657747&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAFLPUNDK2NTM1NzcxNzXRhDwSM/N1+hOLEgMzWvWCE5owjILc7PTVWw
+        1FFwD3LOMDbXKzA0VggoysxNLKpUcCwuTs1NyqnkcuTiAgAAAP//AwCdy/BSWgAAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:57:22 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 939B73A67CF44655000033D104BC2DF0.1.1.m_5
+      NCBI-SID:
+      - D9450A16FF55B810_9643SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=D9450A16FF55B810_9643SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:57:22 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000009.11&rettype=fasta&seq_start=35657747&seq_stop=35657767&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAFLPUNDK2NTM1NzcxNzXQjDzFzBIz83X6E4sSAzNa9YITmjCMgtzs9N
+        VbDUUXAPcs4wNtcrMDRWCCjKzE0sqlRwLC5OzU3KqeRydHR2dHd2dgfCEHdHd0dHEMnFBQAAAP//
+        AwDcRkNxbgAAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:57:31 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 322C409D773A9D45000064B95B91F840.1.1.m_5
+      NCBI-SID:
+      - D4C2F8D826936BFC_779BSID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=D4C2F8D826936BFC_779BSID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:57:31 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/issues/cassettes/test_437/test_invitae_examples.yaml
+++ b/tests/issues/cassettes/test_437/test_invitae_examples.yaml
@@ -1,0 +1,657 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000009.11&rettype=fasta&seq_start=35658020&seq_stop=35658020&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAFLPUNDK2NTM1MLAyMDXRhDwSM/N1+hOLEgMzWvWCE5owjILc7PTVWw
+        1FFwD3LOMDbXKzA0VggoysxNLKpUcCwuTs1NyqnkcubiAgAAAP//AwAkNI4GWgAAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:57:46 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - D0BD088E3BFC1F95000057D4C6919CEC.1.1.m_5
+      NCBI-SID:
+      - 52F2E65413DF94FB_2ABCSID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=52F2E65413DF94FB_2ABCSID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:57:46 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000009.11&rettype=fasta&seq_start=35658020&seq_stop=35658040&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAFLPUNDK2NTM1MLAyMDXQjDxEDBIz83X6E4sSAzNa9YITmjCMgtzs9N
+        VbDUUXAPcs4wNtcrMDRWCCjKzE0sqlRwLC5OzU3KqeRydg5xdnR3DgGSQNrRPQSEuLgAAAAA//8D
+        AGhLJChuAAAA
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:57:49 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - D0BD088E3BFC1F95000045D4CFA6BA83.1.1.m_5
+      NCBI-SID:
+      - 622474AC87716493_A772SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=622474AC87716493_A772SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:57:48 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000009.11&rettype=fasta&seq_start=35658000&seq_stop=35658020&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAFLPUNDK2NTM1MLIEcXwjAyUPDIz81XKE4syEzNK1ZIzigCcovzc1MV
+        LHUU3IOcM4zN9QoMjRUCijJzE4sqFRyLi1Nzk3IqudydnUNCnB3dnR2d3R0dnUFUiDMXFwAAAP//
+        AwDLp58dbgAAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:57:51 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 939B73A67CF44655000050D14DA96985.1.1.m_5
+      NCBI-SID:
+      - 4C0116B72C930C68_B667SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=4C0116B72C930C68_B667SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:57:51 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000009.11&rettype=fasta&seq_start=35657741&seq_stop=35657741&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAFLPUNDK2NTM1NzcxNDXRhDwSM/N1+hOLEgMzWvWCE5owjILc7PTVWw
+        1FFwD3LOMDbXKzA0VggoysxNLKpUcCwuTs1NyqnkcuTiAgAAAP//AwC35QYSWgAAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:57:53 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - D0BD088E3BFC1F95000024D4E2425F8E.1.1.m_5
+      NCBI-SID:
+      - 23F1CE8BE4669F67_49D7SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=23F1CE8BE4669F67_49D7SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:57:53 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000009.11&rettype=fasta&seq_start=35657741&seq_stop=35657761&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAFLPUNDK2NTM1NzcxNDXQjDzFDBIz83X6E4sSAzNa9YITmjCMgtzs9N
+        VbDUUXAPcs4wNtcrMDRWCCjKzE0sqlRwLC5OzU3KqeRydHYEA2dHd2dndyAMcXd05+ICAAAA//8D
+        AKlDe55uAAAA
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:57:55 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 322C409D773A9D45000048B988EAAAE5.1.1.m_5
+      NCBI-SID:
+      - EC9412A5B6DBAACF_9370SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=EC9412A5B6DBAACF_9370SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:57:55 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000009.11&rettype=fasta&seq_start=35657721&seq_stop=35657741&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAFLPUNDK2NTM1NzcyNDXQjDxFDBIz83X6E4sSAzNa9YITmjCMgtzs9N
+        VbDUUXAPcs4wNtcrMDRWCCjKzE0sqlRwLC5OzU3KqeRydA9xd3R3dgZS7iHOIc7u7u6OjlxcAAAA
+        AP//AwBKmvr9bgAAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:57:57 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - D0BD088E3BFC1F95000028D4FE036207.1.1.m_5
+      NCBI-SID:
+      - 3E745C5A5322A516_728ASID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=3E745C5A5322A516_728ASID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:57:57 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NR_003051.3&rettype=fasta&seq_start=275&seq_stop=275&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzC4o3MDA2MDXUM7YyMjfVBWIFj/zcfIXixILM1LxihSA/R4Xk/NyC/LzUvBKF
+        /DSF3MyS/OSM/LyUoszEHLB0QVF+cmpxcWZeukJqXkp+UWZSfl5pck5qYnGqgkaQb1CApg5QHYgH
+        ZIN0cDlycQEAAAD//wMAGM2zDnoAAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:57:59 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - D0BD088E3BFC1F95000056D50A3F7410.1.1.m_5
+      NCBI-SID:
+      - A97F36862DE9C9A2_BA6FSID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=A97F36862DE9C9A2_BA6FSID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:57:59 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NR_003051.3&rettype=fasta&seq_start=275&seq_stop=295&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAByLQQrCMBBF9znFLC2oxJYScCFk141FcgGJ6agDzUzI1Pu3dfcf7/3bGJ7Wdra/
+        nLtr6/pT6xwMkgU0FkJWCKOHJLkIIy8gb8i0SPoKT5Xi/NelSkJV4g8gT1LpJfxLM0ZFOIR7eDTH
+        rdtp2/vDeO+NWQEAAP//AwDawOhqfAAAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:58:01 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 939B73A67CF44655000049D15868376B.1.1.m_5
+      NCBI-SID:
+      - 3CE656B85FDCE2B6_BEBESID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=3CE656B85FDCE2B6_BEBESID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:58:02 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000001.10&rettype=fasta&seq_start=18807339&seq_stop=18807339&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAFDPUMDK0MLCwNzY2NLXRhDwSM/N1+hOLEgMzWvWCE5owjILc7PTVUw
+        1FFwD3LOMDbXKzA0VggoysxNLKpUcCwuTs1NyqnkCuHiAgAAAP//AwC2g8RcWgAAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - close
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:58:04 GMT
+      NCBI-PHID:
+      - 322C409D773A9D45000041B998F51894.1.1.m_5
+      NCBI-SID:
+      - 76693DDF804F6F45_2FC0SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=76693DDF804F6F45_2FC0SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:58:05 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000001.10&rettype=fasta&seq_start=18807339&seq_stop=18807359&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAFDPUMDK0MLCwNzY2NLXQjD1FLBIz83X6E4sSAzNa9YITmjCMgtzs9N
+        VTDUUXAPcs4wNtcrMDRWCCjKzE0sqlRwLC5OzU3KqeQKcXYOcQYT7u7OIUDs7OjuzMUFAAAA//8D
+        AENCHLFuAAAA
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:58:06 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - D0BD088E3BFC1F9500004DD529E0517D.1.1.m_5
+      NCBI-SID:
+      - 73BAC3E7C4A487C6_539BSID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=73BAC3E7C4A487C6_539BSID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:58:07 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/issues/cassettes/test_437/test_oob_dup.yaml
+++ b/tests/issues/cassettes/test_437/test_oob_dup.yaml
@@ -1,0 +1,394 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000009.11&rettype=fasta&seq_start=35658034&seq_stop=35658034&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAFLPUNDK2NTM1MLA2MTXRhDwSM/N1+hOLEgMzWvWCE5owjILc7PTVWw
+        1FFwD3LOMDbXKzA0VggoysxNLKpUcCwuTs1NyqnkcuTiAgAAAP//AwDSXvpeWgAAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:57:33 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 322C409D773A9D45000047B962710F68.1.1.m_5
+      NCBI-SID:
+      - BF954E15F29A6889_CC72SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=BF954E15F29A6889_CC72SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:57:33 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000009.11&rettype=fasta&seq_start=35658033&seq_stop=35658053&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAFLPUNDK2NTM1MLA2NjXQjD1FjBIz83X6E4sSAzNa9YITmjCMgtzs9N
+        VbDUUXAPcs4wNtcrMDRWCCjKzE0sqlRwLC5OzU3KqeRyd3QPAaEQIHAEspydnUMcubgAAAAA//8D
+        AKFKeJ5uAAAA
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:57:35 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 939B73A67CF44655000025D12265497B.1.1.m_5
+      NCBI-SID:
+      - C53BABC9F649216A_D325SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=C53BABC9F649216A_D325SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:57:35 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000009.11&rettype=fasta&seq_start=35658038&seq_stop=35658040&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAFLPUNDK2NTM1MLA2MLXQjDxEDBIz83X6E4sSAzNa9YITmjCMgtzs9N
+        VbDUUXAPcs4wNtcrMDRWCCjKzE0sqlRwLC5OzU3KqeRyD3Hk4gIAAAD//wMAnn+I2FwAAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:57:38 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 322C409D773A9D45000048B96ECBBE2B.1.1.m_5
+      NCBI-SID:
+      - 995898FF856838A8_48C9SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=995898FF856838A8_48C9SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:57:38 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000009.11&rettype=fasta&seq_start=35658040&seq_stop=35658040&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAFLPUNDK2NTM1MLAxMDXRhDwSM/N1+hOLEgMzWvWCE5owjILc7PTVWw
+        1FFwD3LOMDbXKzA0VggoysxNLKpUcCwuTs1NyqnkcuTiAgAAAP//AwCy3/HeWgAAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:57:39 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - D0BD088E3BFC1F95000034D4B66314A8.1.1.m_5
+      NCBI-SID:
+      - 514F9B5A8760A13A_68A8SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=514F9B5A8760A13A_68A8SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:57:40 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000009.11&rettype=fasta&seq_start=35658018&seq_stop=35658040&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAFLPUNDK2NTM1MLA0MLXQjDxEDBIz83X6E4sSAzNa9YITmjCMgtzs9N
+        VbDUUXAPcs4wNtcrMDRWCCjKzE0sqlRwLC5OzU3KqeRyD3F2DnF2dHcOAZJA2tE9BIS4uAAAAAD/
+        /wMAwkyRzHAAAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:57:42 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - D0BD088E3BFC1F9500004ED4BBC1B657.1.1.m_5
+      NCBI-SID:
+      - E473C8335E7AC266_409ESID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=E473C8335E7AC266_409ESID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:57:42 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000009.11&rettype=fasta&seq_start=35658034&seq_stop=35658036&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAFLPUNDK2NTM1MLA2MTXSjDTMEjPzdfoTixIDM1r1ghOaMIyC3Oz01V
+        sNRRcA9yzjA21yswNFYIKMrMTSyqVHAsLk7NTcqp5HJ0D+HiAgAAAP//AwAE0yTcXAAAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:57:44 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 939B73A67CF44655000026D13C57E639.1.1.m_5
+      NCBI-SID:
+      - A3F344DD80098BCE_CE79SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=A3F344DD80098BCE_CE79SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:57:44 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/issues/cassettes/test_477/test_pair[COX6A2-GRCh38-rs1033792906].yaml
+++ b/tests/issues/cassettes/test_477/test_pair[COX6A2-GRCh38-rs1033792906].yaml
@@ -1,0 +1,67 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000016.10&rettype=fasta&seq_start=31428431&seq_stop=31428431&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAJDMz1DAytjQxMjCxNjQ10YQ8EjPzdfoTixIDM1r1ghOaMIyC3Oz01V
+        MDTTUXAPcs4wttArMDRRCCjKzE0sqlRwLC5OzU3KqeRy5uICAAAA//8DAHDmQj1bAAAA
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:59:05 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - D0BD088E3BFC1F95000015D5AD18B8A7.1.1.m_5
+      NCBI-SID:
+      - E647595C1B98C7A3_F456SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=E647595C1B98C7A3_F456SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:59:05 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/issues/cassettes/test_477/test_pair[COX6A2-GRCh38-rs200780049].yaml
+++ b/tests/issues/cassettes/test_477/test_pair[COX6A2-GRCh38-rs200780049].yaml
@@ -1,0 +1,198 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000016.10&rettype=fasta&seq_start=31428324&seq_stop=31428324&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAJDMz1DAytjQxMjC2MjE10YQ8EjPzdfoTixIDM1r1ghOaMIyC3Oz01V
+        MDTTUXAPcs4wttArMDRRCCjKzE0sqlRwLC5OzU3KqeRy5OICAAAA//8DALkIWXBbAAAA
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:59:16 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 322C409D773A9D45000059BA7B0BE3D3.1.1.m_5
+      NCBI-SID:
+      - 54E9335B9F8C2948_D663SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=54E9335B9F8C2948_D663SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:59:15 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NM_005205.3&rettype=fasta&seq_start=105&seq_stop=105&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLz8403MDA1MjDVM7YyNDDVBWIFj/zcfIXixILM1LxiheTKkvzkjKL83FSFZIX8
+        isyUxOJUheLSpNK8zBIFM0cjBQ1n/wggramjkBvk58gVwsUFAAAA//8DAPaopXJVAAAA
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:59:18 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 939B73A67CF44655000060D1F1491620.1.1.m_5
+      NCBI-SID:
+      - 5E663C7089676AAB_E795SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=5E663C7089676AAB_E795SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:59:18 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NM_005205.3&rettype=fasta&seq_start=105&seq_stop=125&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLz8403MDA1MjDVM7YyNDDVNTQyVfDIz81XKE4syEzNK1ZIrizJT84oys9NVUhW
+        yK/ITEksTlUoLk0qzcssUTBzNFLQcPaPANKaOgq5QX6OXCHu7s4hISHuzs4hziHujkAeEHBxAQAA
+        AP//AwC82KhBaQAAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:59:20 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 322C409D773A9D45000039BA89258904.1.1.m_5
+      NCBI-SID:
+      - 80654D222C6DFB9E_AFB0SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=80654D222C6DFB9E_AFB0SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:59:20 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/issues/cassettes/test_477/test_pair[COX6A2-GRCh38-rs375688325].yaml
+++ b/tests/issues/cassettes/test_477/test_pair[COX6A2-GRCh38-rs375688325].yaml
@@ -1,0 +1,197 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000016.10&rettype=fasta&seq_start=31427732&seq_stop=31427732&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAJDMz1DAytjQxMjc3NjI10YQ8EjPzdfoTixIDM1r1ghOaMIyC3Oz01V
+        MDTTUXAPcs4wttArMDRRCCjKzE0sqlRwLC5OzU3KqeRy5uICAAAA//8DAM/msEhbAAAA
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:59:36 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - D0BD088E3BFC1F95000022D5E842CC35.1.1.m_5
+      NCBI-SID:
+      - 66A0C40875C85780_BD3BSID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=66A0C40875C85780_BD3BSID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:59:35 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NM_005205.3&rettype=fasta&seq_start=439&seq_stop=439&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLz8403MDA1MjDVM7YyMbbUBWIFj/zcfIXixILM1LxiheTKkvzkjKL83FSFZIX8
+        isyUxOJUheLSpNK8zBIFM0cjBQ1n/wggramjkBvk58jlzsUFAAAA//8DAJPtAAJVAAAA
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:59:37 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 939B73A67CF44655000047D23DA25AAB.1.1.m_5
+      NCBI-SID:
+      - B6F8BF7E363622F1_55EASID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=B6F8BF7E363622F1_55EASID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:59:37 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NM_005205.3&rettype=fasta&seq_start=439&seq_stop=440&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLz8403MDA1MjDVM7YyMbbUNTExUPDIz81XKE4syEzNK1ZIrizJT84oys9NVUhW
+        yK/ITEksTlUoLk0qzcssUTBzNFLQcPaPANKaOgq5QX6OXO6OXFwAAAAA//8DABC7tftWAAAA
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:59:40 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - D0BD088E3BFC1F9500005CD5ED7439DD.1.1.m_5
+      NCBI-SID:
+      - CC6E343BC06D732F_A5CDSID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=CC6E343BC06D732F_A5CDSID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:59:40 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/issues/cassettes/test_477/test_pair[COX6A2-GRCh38-rs755670336].yaml
+++ b/tests/issues/cassettes/test_477/test_pair[COX6A2-GRCh38-rs755670336].yaml
@@ -1,0 +1,198 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000016.10&rettype=fasta&seq_start=31428421&seq_stop=31428421&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAJDMz1DAytjQxMjCxMjQ10YQ8EjPzdfoTixIDM1r1ghOaMIyC3Oz01V
+        MDTTUXAPcs4wttArMDRRCCjKzE0sqlRwLC5OzU3KqeRy5+ICAAAA//8DADRwaVZbAAAA
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:59:09 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - D0BD088E3BFC1F9500002DD5B3F453A2.1.1.m_5
+      NCBI-SID:
+      - EFEBB97E9DDD2350_1B6BSID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=EFEBB97E9DDD2350_1B6BSID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:59:08 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NM_005205.3&rettype=fasta&seq_start=8&seq_stop=8&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLz8403MDA1MjDVM7ay0LVQ8MjPzVcoTizITM0rVkiuLMlPzijKz01VSFbIr8hM
+        SSxOVSguTSrNyyxRMHM0UtBw9o8A0po6CrlBfo5czlxcAAAAAP//AwBe2FcJUQAAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:59:11 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 322C409D773A9D45000039BA68C8762E.1.1.m_5
+      NCBI-SID:
+      - 25042448AAC864F3_58EASID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=25042448AAC864F3_58EASID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:59:11 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NM_005205.3&rettype=fasta&seq_start=8&seq_stop=28&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLz8403MDA1MjDVM7ay0DWyUPDIz81XKE4syEzNK1ZIrizJT84oys9NVUhWyK/I
+        TEksTlUoLk0qzcssUTBzNFLQcPaPANKaOgq5QX6OXM6O7o7OIc6OjkCGe4i7Y0iIu7szFxcAAAD/
+        /wMAUs++62YAAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:59:12 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 322C409D773A9D45000045BA71F15F39.1.1.m_5
+      NCBI-SID:
+      - D4915774F7687A7F_A641SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=D4915774F7687A7F_A641SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:59:13 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/issues/cassettes/test_477/test_pair[COX6A2-GRCh38-rs756406653].yaml
+++ b/tests/issues/cassettes/test_477/test_pair[COX6A2-GRCh38-rs756406653].yaml
@@ -1,0 +1,67 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000016.10&rettype=fasta&seq_start=31427730&seq_stop=31427730&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAJDMz1DAytjQxMjc3NjA10YQ8EjPzdfoTixIDM1r1ghOaMIyC3Oz01V
+        MDTTUXAPcs4wttArMDRRCCjKzE0sqlRwLC5OzU3KqeRy5uICAAAA//8DAGcM5gFbAAAA
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:59:47 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 322C409D773A9D45000018BABFBE1EB6.1.1.m_5
+      NCBI-SID:
+      - D223B96BEA8C9E7A_946ASID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=D223B96BEA8C9E7A_946ASID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:59:47 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/issues/cassettes/test_477/test_pair[COX6A2-GRCh38-rs764753905].yaml
+++ b/tests/issues/cassettes/test_477/test_pair[COX6A2-GRCh38-rs764753905].yaml
@@ -1,0 +1,197 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000016.10&rettype=fasta&seq_start=31427775&seq_stop=31427775&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAJDMz1DAytjQxMjc3NzU10YQ8EjPzdfoTixIDM1r1ghOaMIyC3Oz01V
+        MDTTUXAPcs4wttArMDRRCCjKzE0sqlRwLC5OzU3KqeRy5uICAAAA//8DAEJQGdxbAAAA
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:59:21 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 939B73A67CF44655000037D2012A69D4.1.1.m_5
+      NCBI-SID:
+      - C7E272CE05884366_8DC0SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=C7E272CE05884366_8DC0SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:59:22 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NM_005205.3&rettype=fasta&seq_start=396&seq_stop=396&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLz8403MDA1MjDVM7YytjTTBWIFj/zcfIXixILM1LxiheTKkvzkjKL83FSFZIX8
+        isyUxOJUheLSpNK8zBIFM0cjBQ1n/wggramjkBvk58jlzsUFAAAA//8DAJ1+Y5FVAAAA
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:59:25 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - D0BD088E3BFC1F95000059D5CF772A1C.1.1.m_5
+      NCBI-SID:
+      - 70D7715EBEBD7E43_30F3SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=70D7715EBEBD7E43_30F3SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:59:24 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NM_005205.3&rettype=fasta&seq_start=396&seq_stop=397&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLz8403MDA1MjDVM7YytjTTNbY0V/DIz81XKE4syEzNK1ZIrizJT84oys9NVUhW
+        yK/ITEksTlUoLk0qzcssUTBzNFLQcPaPANKaOgq5QX6OXO6OXFwAAAAA//8DAG0Mdk1WAAAA
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:59:26 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 322C409D773A9D4500005ABA9B07548F.1.1.m_5
+      NCBI-SID:
+      - 18DB94CBC09842F1_1BCCSID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=18DB94CBC09842F1_1BCCSID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:59:27 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/issues/cassettes/test_477/test_pair[COX6A2-GRCh38-rs909673485].yaml
+++ b/tests/issues/cassettes/test_477/test_pair[COX6A2-GRCh38-rs909673485].yaml
@@ -1,0 +1,198 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000016.10&rettype=fasta&seq_start=31427771&seq_stop=31427771&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAJDMz1DAytjQxMjc3NzQ10YQ8EjPzdfoTixIDM1r1ghOaMIyC3Oz01V
+        MDTTUXAPcs4wttArMDRRCCjKzE0sqlRwLC5OzU3KqeRy5+ICAAAA//8DAM4tvUlbAAAA
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:59:28 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 939B73A67CF44655000061D2186E1FC1.1.1.m_5
+      NCBI-SID:
+      - AB7EF20951CBA503_BD20SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=AB7EF20951CBA503_BD20SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:59:29 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NM_005205.3&rettype=fasta&seq_start=400&seq_stop=400&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLz8403MDA1MjDVM7YyMTDQBWIFj/zcfIXixILM1LxiheTKkvzkjKL83FSFZIX8
+        isyUxOJUheLSpNK8zBIFM0cjBQ1n/wggramjkBvk58jlzMUFAAAA//8DAEs0cmhVAAAA
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:59:31 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 939B73A67CF44655000035D21FA06331.1.1.m_5
+      NCBI-SID:
+      - 440F0DBDD1D2D3EC_9498SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=440F0DBDD1D2D3EC_9498SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:59:31 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NM_005205.3&rettype=fasta&seq_start=400&seq_stop=420&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLz8403MDA1MjDVM7YyMTDQNTEyUPDIz81XKE4syEzNK1ZIrizJT84oys9NVUhW
+        yK/ITEksTlUoLk0qzcssUTBzNFLQcPaPANKaOgq5QX6OXM5A4O7u6OzuDGMBIRcXAAAA//8DAO79
+        uVhpAAAA
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:59:33 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 939B73A67CF44655000060D22A123610.1.1.m_5
+      NCBI-SID:
+      - D7405E2125452046_4E21SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=D7405E2125452046_4E21SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:59:33 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/issues/cassettes/test_477/test_pair[COX6A2-GRCh38-rs961248971].yaml
+++ b/tests/issues/cassettes/test_477/test_pair[COX6A2-GRCh38-rs961248971].yaml
@@ -1,0 +1,132 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000016.10&rettype=fasta&seq_start=31427731&seq_stop=31427731&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAJDMz1DAytjQxMjc3NjQ10YQ8EjPzdfoTixIDM1r1ghOaMIyC3Oz01V
+        MDTTUXAPcs4wttArMDRRCCjKzE0sqlRwLC5OzU3KqeQK4eICAAAA//8DAMbMJDxbAAAA
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:59:41 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 322C409D773A9D4500004ABAB1B81425.1.1.m_5
+      NCBI-SID:
+      - E4B3E1D81226A1EB_AE8ASID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=E4B3E1D81226A1EB_AE8ASID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:59:42 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NM_005205.3&rettype=fasta&seq_start=440&seq_stop=440&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLz8403MDA1MjDVM7YyMTHQBWIFj/zcfIXixILM1LxiheTKkvzkjKL83FSFZIX8
+        isyUxOJUheLSpNK8zBIFM0cjBQ1n/wggramjkBvk58jlyMUFAAAA//8DAKQMZ+1VAAAA
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:59:43 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 939B73A67CF4465500002ED258E7542B.1.1.m_5
+      NCBI-SID:
+      - 1C9BDB4A53A173E7_A463SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=1C9BDB4A53A173E7_A463SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:59:44 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/issues/cassettes/test_477/test_pair[GPHB5-GRCh37-rs1204774077].yaml
+++ b/tests/issues/cassettes/test_477/test_pair[GPHB5-GRCh37-rs1204774077].yaml
@@ -1,0 +1,198 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000014.8&rettype=fasta&seq_start=63779558&seq_stop=63779558&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAJDEz0LKzNjc3NLU1MLXRhDwSM/N1+hOLEgMzWvWCE5owjILc7PTVUw
+        NNFRcA9yzjA21yswNFYIKMrMTSyqVHAsLk7NTcqp5Arh4gIAAAD//wMAQtvi81oAAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:58:38 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 322C409D773A9D4500002FBA11BB18D0.1.1.m_5
+      NCBI-SID:
+      - AA0A6DBB5D042576_18F7SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=AA0A6DBB5D042576_18F7SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:58:39 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NM_145171.3&rettype=fasta&seq_start=534&seq_stop=534&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLz8403NDE1NDfUM7YyNTbRBWIFj/zcfIXixILM1LxihfScyuT8gqL8ktTMPIWM
+        /KLc/LxUheLSpNK8zBKFpNSSRAVTBQ33AA8nU00dhdwgP0cuRy4uAAAAAP//AwCOq2a2VwAAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:58:41 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 322C409D773A9D4500005ABA166723B1.1.1.m_5
+      NCBI-SID:
+      - 8D633E2FC000A6F1_5AE0SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=8D633E2FC000A6F1_5AE0SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:58:41 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NM_145171.3&rettype=fasta&seq_start=534&seq_stop=543&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLz8403NDE1NDfUM7YyNTbRNTUxVvDIz81XKE4syEzNK1ZIz6lMzi8oyi9JzcxT
+        yMgvys3PS1UoLk0qzcssUUhKLUlUMFXQcA/wcDLV1FHIDfJz5HJ0dnYEQiDJxQUAAAD//wMAz67Y
+        GWAAAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:58:44 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - D0BD088E3BFC1F95000015D5629C9757.1.1.m_5
+      NCBI-SID:
+      - 74BF1B8640E2EEBC_3EB6SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=74BF1B8640E2EEBC_3EB6SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:58:44 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/issues/cassettes/test_477/test_pair[GPHB5-GRCh37-rs1221379530].yaml
+++ b/tests/issues/cassettes/test_477/test_pair[GPHB5-GRCh37-rs1221379530].yaml
@@ -1,0 +1,198 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000014.8&rettype=fasta&seq_start=63784562&seq_stop=63784562&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAJDEz0LKzNjcwsTUzMjXRhDwSM/N1+hOLEgMzWvWCE5owjILc7PTVUw
+        NNFRcA9yzjA21yswNFYIKMrMTSyqVHAsLk7NTcqp5HLk4gIAAAD//wMAzAOXvVoAAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:58:18 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 939B73A67CF44655000059D189FE1E64.1.1.m_5
+      NCBI-SID:
+      - 2061511F7467A1CE_E29DSID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=2061511F7467A1CE_E29DSID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:58:19 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NM_145171.3&rettype=fasta&seq_start=59&seq_stop=59&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLz8403NDE1NDfUM7YytdQ1tVTwyM/NVyhOLMhMzStWSM+pTM4vKMovSc3MU8jI
+        L8rNz0tVKC5NKs3LLFFISi1JVDBV0HAP8HAy1dRRyA3yc+QK4eICAAAA//8DANRpjvFVAAAA
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:58:21 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 322C409D773A9D45000043B9C4253811.1.1.m_5
+      NCBI-SID:
+      - F71CFFDCFF445431_FCDDSID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=F71CFFDCFF445431_FCDDSID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:58:21 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NM_145171.3&rettype=fasta&seq_start=59&seq_stop=79&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLz8403NDE1NDfUM7YytdQ1t1TwyM/NVyhOLMhMzStWSM+pTM4vKMovSc3MU8jI
+        L8rNz0tVKC5NKs3LLFFISi1JVDBV0HAP8HAy1dRRyA3yc+QKcXd0dHcOcXd3dgwJcXYOcQaRXFwA
+        AAAA//8DAEq73mVpAAAA
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:58:23 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 322C409D773A9D45000054B9CC10966A.1.1.m_5
+      NCBI-SID:
+      - C1689359F0DF411D_34DDSID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=C1689359F0DF411D_34DDSID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:58:23 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/issues/cassettes/test_477/test_pair[GPHB5-GRCh37-rs1299953722].yaml
+++ b/tests/issues/cassettes/test_477/test_pair[GPHB5-GRCh37-rs1299953722].yaml
@@ -1,0 +1,67 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000014.8&rettype=fasta&seq_start=63785599&seq_stop=63785599&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAJDEz0LKzNjcwtTU0tLXRhDwSM/N1+hOLEgMzWvWCE5owjILc7PTVUw
+        NNFRcA9yzjA21yswNFYIKMrMTSyqVHAsLk7NTcqp5Arh4gIAAAD//wMAGmc4RFoAAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:58:09 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 322C409D773A9D4500002EB9A0C51626.1.1.m_5
+      NCBI-SID:
+      - A226273423F44AE4_69C8SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=A226273423F44AE4_69C8SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:58:09 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/issues/cassettes/test_477/test_pair[GPHB5-GRCh37-rs1380832691].yaml
+++ b/tests/issues/cassettes/test_477/test_pair[GPHB5-GRCh37-rs1380832691].yaml
@@ -1,0 +1,198 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000014.8&rettype=fasta&seq_start=63779647&seq_stop=63779647&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAJDEz0LKzNjc3NLMxNzXRhDwSM/N1+hOLEgMzWvWCE5owjILc7PTVUw
+        NNFRcA9yzjA21yswNFYIKMrMTSyqVHAsLk7NTcqp5Arh4gIAAAD//wMADk4DRloAAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:58:25 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 939B73A67CF44655000054D19FF80BA8.1.1.m_5
+      NCBI-SID:
+      - DB7EF1D96AA215F5_4148SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=DB7EF1D96AA215F5_4148SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:58:25 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NM_145171.3&rettype=fasta&seq_start=445&seq_stop=445&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLz8403NDE1NDfUM7YyMTHVBWIFj/zcfIXixILM1LxihfScyuT8gqL8ktTMPIWM
+        /KLc/LxUheLSpNK8zBKFpNSSRAVTBQ33AA8nU00dhdwgP0cuRy4uAAAAAP//AwBWWAYvVwAAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:58:27 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 322C409D773A9D4500002FB9DFFAD2EB.1.1.m_5
+      NCBI-SID:
+      - 649F6C2A7A059844_0B2DSID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=649F6C2A7A059844_0B2DSID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:58:27 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NM_145171.3&rettype=fasta&seq_start=445&seq_stop=450&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLz8403NDE1NDfUM7YyMTHVNTE1UPDIz81XKE4syEzNK1ZIz6lMzi8oyi9JzcxT
+        yMgvys3PS1UoLk0qzcssUUhKLUlUMFXQcA/wcDLV1FHIDfJz5HIMcQ5xd+TiAgAAAP//AwCpSYbr
+        XAAAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:58:29 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 322C409D773A9D45000051B9EC3FF9A1.1.1.m_5
+      NCBI-SID:
+      - 4145874E98EF8971_48BFSID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=4145874E98EF8971_48BFSID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:58:30 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/issues/cassettes/test_477/test_pair[GPHB5-GRCh37-rs144659601].yaml
+++ b/tests/issues/cassettes/test_477/test_pair[GPHB5-GRCh37-rs144659601].yaml
@@ -1,0 +1,67 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000014.8&rettype=fasta&seq_start=63779543&seq_stop=63779543&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAJDEz0LKzNjc3NLUxNjXRhDwSM/N1+hOLEgMzWvWCE5owjILc7PTVUw
+        NNFRcA9yzjA21yswNFYIKMrMTSyqVHAsLk7NTcqp5HLm4gIAAAD//wMAMmN+FVoAAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:58:46 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - D0BD088E3BFC1F9500003ED569FC8BC9.1.1.m_5
+      NCBI-SID:
+      - D4BF080FC12F5E39_830DSID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=D4BF080FC12F5E39_830DSID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:58:46 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/issues/cassettes/test_477/test_pair[GPHB5-GRCh37-rs753041439].yaml
+++ b/tests/issues/cassettes/test_477/test_pair[GPHB5-GRCh37-rs753041439].yaml
@@ -1,0 +1,198 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000014.8&rettype=fasta&seq_start=63779638&seq_stop=63779638&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAJDEz0LKzNjc3NLM2MLXRhDwSM/N1+hOLEgMzWvWCE5owjILc7PTVUw
+        NNFRcA9yzjA21yswNFYIKMrMTSyqVHAsLk7NTcqp5HLn4gIAAAD//wMA4wqGhloAAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:58:32 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - D0BD088E3BFC1F95000034D53E283A79.1.1.m_5
+      NCBI-SID:
+      - DECFEF1A2912765A_D86DSID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=DECFEF1A2912765A_D86DSID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:58:32 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NM_145171.3&rettype=fasta&seq_start=454&seq_stop=454&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLz8403NDE1NDfUM7YyMTXRBWIFj/zcfIXixILM1LxihfScyuT8gqL8ktTMPIWM
+        /KLc/LxUheLSpNK8zBKFpNSSRAVTBQ33AA8nU00dhdwgP0cuZy4uAAAAAP//AwD8Z33FVwAAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:58:35 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - D0BD088E3BFC1F95000035D5449770C8.1.1.m_5
+      NCBI-SID:
+      - 84306B5BBEF8CEBB_E6E4SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=84306B5BBEF8CEBB_E6E4SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:58:35 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NM_145171.3&rettype=fasta&seq_start=454&seq_stop=474&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLz8403NDE1NDfUM7YyMTXRNTE3UfDIz81XKE4syEzNK1ZIz6lMzi8oyi9JzcxT
+        yMgvys3PS1UoLk0qzcssUUhKLUlUMFXQcA/wcDLV1FHIDfJz5HJ2dw5xBGIgAkF3Z0d3R2cuLgAA
+        AAD//wMAtX9ExWsAAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:58:37 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - D0BD088E3BFC1F95000029D54A599695.1.1.m_5
+      NCBI-SID:
+      - 7EF3146B62184DD0_402DSID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=7EF3146B62184DD0_402DSID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:58:37 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/issues/cassettes/test_477/test_pair[GPHB5-GRCh37-rs982881702].yaml
+++ b/tests/issues/cassettes/test_477/test_pair[GPHB5-GRCh37-rs982881702].yaml
@@ -1,0 +1,198 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000014.8&rettype=fasta&seq_start=63785592&seq_stop=63785592&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAJDEz0LKzNjcwtTU0sjXRhDwSM/N1+hOLEgMzWvWCE5owjILc7PTVUw
+        NNFRcA9yzjA21yswNFYIKMrMTSyqVHAsLk7NTcqp5HLm4gIAAAD//wMA8uGGzloAAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:58:12 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 939B73A67CF4465500002FD171CBAEAF.1.1.m_5
+      NCBI-SID:
+      - 0CDC05E4D2817EC4_293CSID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=0CDC05E4D2817EC4_293CSID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:58:12 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NM_145171.3&rettype=fasta&seq_start=2&seq_stop=2&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLz8403NDE1NDfUM7Yy0jVS8MjPzVcoTizITM0rVkjPqUzOLyjKL0nNzFPIyC/K
+        zc9LVSguTSrNyyxRSEotSVQwVdBwD/BwMtXUUcgN8nPkcufiAgAAAP//AwA04cYGUwAAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:58:14 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 322C409D773A9D45000038B9AE1A9DE9.1.1.m_5
+      NCBI-SID:
+      - 4C902DAC0E1D24FE_DDF3SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=4C902DAC0E1D24FE_DDF3SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:58:14 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NM_145171.3&rettype=fasta&seq_start=2&seq_stop=22&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLz8403NDE1NDfUM7Yy0jUyUvDIz81XKE4syEzNK1ZIz6lMzi8oyi9JzcxTyMgv
+        ys3PS1UoLk0qzcssUUhKLUlUMFXQcA/wcDLV1FHIDfJz5HJ3dHQMcQ4JcXQPcXd2BJIhIc6OXFwA
+        AAAA//8DALTr1LloAAAA
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:58:16 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 939B73A67CF44655000048D18176816D.1.1.m_5
+      NCBI-SID:
+      - 945CC181581AF121_1D6FSID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=945CC181581AF121_1D6FSID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:58:17 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/issues/cassettes/test_477/test_pair[GPHB5-GRCh38-rs1204774077].yaml
+++ b/tests/issues/cassettes/test_477/test_pair[GPHB5-GRCh38-rs1204774077].yaml
@@ -1,0 +1,67 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000014.9&rettype=fasta&seq_start=63312844&seq_stop=63312844&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAJDEz1LKzNjY0MjCxMTXRhDwSM/N1+hOLEgMzWvWCE5owjILc7PTVUw
+        NNFRcA9yzjC20CswNFEIKMrMTSyqVHAsLk7NTcqp5Arh4gIAAAD//wMAvZ3ys1oAAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:59:00 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - D0BD088E3BFC1F9500005AD59F33CEBF.1.1.m_5
+      NCBI-SID:
+      - 446CC2B26F119A9D_22BESID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=446CC2B26F119A9D_22BESID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:59:01 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/issues/cassettes/test_477/test_pair[GPHB5-GRCh38-rs1221379530].yaml
+++ b/tests/issues/cassettes/test_477/test_pair[GPHB5-GRCh38-rs1221379530].yaml
@@ -1,0 +1,67 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000014.9&rettype=fasta&seq_start=63317848&seq_stop=63317848&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAJDEz1LKzNjY0NzCxMLXRhDwSM/N1+hOLEgMzWvWCE5owjILc7PTVUw
+        NNFRcA9yzjC20CswNFEIKMrMTSyqVHAsLk7NTcqp5HLk4gIAAAD//wMAITT1hVoAAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:58:53 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - D0BD088E3BFC1F9500003CD5835AB72D.1.1.m_5
+      NCBI-SID:
+      - F8A02C219B41BBD3_3DB6SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=F8A02C219B41BBD3_3DB6SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:58:53 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/issues/cassettes/test_477/test_pair[GPHB5-GRCh38-rs1299953722].yaml
+++ b/tests/issues/cassettes/test_477/test_pair[GPHB5-GRCh38-rs1299953722].yaml
@@ -1,0 +1,67 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000014.9&rettype=fasta&seq_start=63318885&seq_stop=63318885&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAJDEz1LKzNjY0MLCwtTXRhDwSM/N1+hOLEgMzWvWCE5owjILc7PTVUw
+        NNFRcA9yzjC20CswNFEIKMrMTSyqVHAsLk7NTcqp5Arh4gIAAAD//wMA5o+Iq1oAAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:58:48 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 322C409D773A9D45000037BA25C1FE87.1.1.m_5
+      NCBI-SID:
+      - 0EC0FCBCAAF177CA_20A1SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=0EC0FCBCAAF177CA_20A1SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:58:48 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/issues/cassettes/test_477/test_pair[GPHB5-GRCh38-rs1380832691].yaml
+++ b/tests/issues/cassettes/test_477/test_pair[GPHB5-GRCh38-rs1380832691].yaml
@@ -1,0 +1,67 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000014.9&rettype=fasta&seq_start=63312933&seq_stop=63312933&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAJDEz1LKzNjY0MjS2NjXRhDwSM/N1+hOLEgMzWvWCE5owjILc7PTVUw
+        NNFRcA9yzjC20CswNFEIKMrMTSyqVHAsLk7NTcqp5Arh4gIAAAD//wMA0FGFbVoAAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:58:55 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 322C409D773A9D45000052BA3923D877.1.1.m_5
+      NCBI-SID:
+      - 1BE061611D55D5B0_5A57SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=1BE061611D55D5B0_5A57SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:58:56 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/issues/cassettes/test_477/test_pair[GPHB5-GRCh38-rs144659601].yaml
+++ b/tests/issues/cassettes/test_477/test_pair[GPHB5-GRCh38-rs144659601].yaml
@@ -1,0 +1,67 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000014.9&rettype=fasta&seq_start=63312829&seq_stop=63312829&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAJDEz1LKzNjY0MjCyNLXRhDwSM/N1+hOLEgMzWvWCE5owjILc7PTVUw
+        NNFRcA9yzjC20CswNFEIKMrMTSyqVHAsLk7NTcqp5HLm4gIAAAD//wMAvKUKUVoAAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:59:03 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 322C409D773A9D45000035BA4AD2E0D6.1.1.m_5
+      NCBI-SID:
+      - 46AE8C00E584ED76_74C6SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=46AE8C00E584ED76_74C6SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:59:03 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/issues/cassettes/test_477/test_pair[GPHB5-GRCh38-rs753041439].yaml
+++ b/tests/issues/cassettes/test_477/test_pair[GPHB5-GRCh38-rs753041439].yaml
@@ -1,0 +1,67 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000014.9&rettype=fasta&seq_start=63312924&seq_stop=63312924&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAJDEz1LKzNjY0MjSyMTXRhDwSM/N1+hOLEgMzWvWCE5owjILc7PTVUw
+        NNFRcA9yzjC20CswNFEIKMrMTSyqVHAsLk7NTcqp5HLn4gIAAAD//wMAzTiX4FoAAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:58:58 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 939B73A67CF4465500004BD1D1417E79.1.1.m_5
+      NCBI-SID:
+      - EE9B718F04FAE066_68E3SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=EE9B718F04FAE066_68E3SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:58:58 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/issues/cassettes/test_477/test_pair[GPHB5-GRCh38-rs982881702].yaml
+++ b/tests/issues/cassettes/test_477/test_pair[GPHB5-GRCh38-rs982881702].yaml
@@ -1,0 +1,67 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000014.9&rettype=fasta&seq_start=63318878&seq_stop=63318878&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAALLzc443AAJDEz1LKzNjY0MLC3MLXRhDwSM/N1+hOLEgMzWvWCE5owjILc7PTVUw
+        NNFRcA9yzjC20CswNFEIKMrMTSyqVHAsLk7NTcqp5HLm4gIAAAD//wMAPXGh8loAAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:58:51 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 322C409D773A9D45000031BA2C34BBE6.1.1.m_5
+      NCBI-SID:
+      - 14024452E4D0A174_5515SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=14024452E4D0A174_5515SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:58:50 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/issues/cassettes/test_525/test_525.yaml
+++ b/tests/issues/cassettes/test_525/test_525.yaml
@@ -1,0 +1,173 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NM_000551.3&rettype=fasta&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAExRPWvDQAzd71fc2EJaHELWgtAgD2mGIroW03ow1Pbhs/P7Kz05pNiW9fn0JL1d
+        37+apjmfj6+n3M7jnGtXhn6q+TZPuR1K6X9fLsP002153cZ5yXUrZelrNfXps708H/K6dFP9Xoay
+        5lu3DN205uMhjx9XSszK4oJFlZiIxU3/qbCKkL0WVTXDMi0ASXuR4EtKqm6y5bt0A2UOdXciTEIB
+        b8DWmry/7AkJ8KYDioHnKoUKIlDC7SniPEXBVCNJkgnSAPA24bXR1Ds5GwEnUdciCicFMkiKptiF
+        VbntvIG0Z4M270D0j08UP0ywQetHttOJ3XLAyD6Xn0Fi04oTEBZkT/IdYeeMzdm0cRPC3NHyDwAA
+        //+Ml1GO5DYMRP91K0IfugDvf5aI75V6ZtMbIJNg0bZliipWFWkBS4iJNbvcdyYKYF9sqIYwU+hN
+        0XlhanqosQnNqikkJalgdi93rzbwjVoeZrK6G8x/nO2Y3rCqZosCx4YokyAHWOR2rxt0Q6tZ0iyp
+        +5uQXN3X7vUAMqEK0lDn1YLS4m6QyZRf1B5ygztUmd1nARyUpbdScxAez7ItNEW25YZbRUyl2sOG
+        ujX5ErWupo4ITDjJ02DBxVTCE83N2Q9058DzUoPT5LwGXRKaAG4loKhxwhiiAGbitNHudU3iUHpt
+        k2vucQxKMvnP29tlFIVKzPXcKY+zCXWzGQxbXUGugRRoDwWrDr6lIg3abm09ikNV6txUk7vwymvC
+        FbQCQoGdWFSsTWOyYScSh6UtiIWuEqpL/jYFLkyO6jUZXmygTOtlRjgpf+sIvPPMYRIfXlFOzK2p
+        1DCFhAkibi0NOQjvckCqM6IuVHGiGZ6tTnkolpgktycJ0tPyDisOnLTcyOMWXNfwjs8E8tWjyeCV
+        R6A4EWeD7Xsg1oFGBzBRKmMtvtaPxA2raRSoInCjx3UsxPnZfaKr/3QSybpPfoEhkQ9+MYxYr7Kc
+        Cw5LrRw8JCShvT87VfuUnO7DVQZt6/Ewff9//WN9tWq0JRSrNYeTDglFW4MvcXPxyIj6PYZR09pw
+        fC/vFaSkpHGpHY1hQjzCC3MqeX5U3x5NUQX2hiGfzGIP2WZvDe9U2mvupKksoDy/84BS9IKyMZEK
+        CO7fBNrRx+S7on1Uzw7ZgjZNG4lGEUlOryk/T5zm+4glqbEEyXAwRCXCahiVJfgTbyK1jd+8QsPS
+        8r38bcUHbVqgmrYIZT3e/VvyMjLX9iAVzaKsQykDrh0ZfGTAyXeV1h9ZcjAsljNU6LYzTPWDrmPK
+        O5mvGBj3havTbKLJXREgkO3E2Dr4jujXywIhbaQCr0Zf2xfSBnL7iMGPa9gZWpZEgfqxnqxd41D2
+        gB2LJbKabAcU6UfzctJKnOOgkeEE3ViE/dBHHIdGMrNfup3jkmMfk8Bz5KM4m43msZq1GhhQGgw/
+        yyS2KdtoTKIdijyvsjgJeTTbcwuehkofOy7b7rztEV0qXdtNxU8awyyrNBg9pP76pwIZ234gq39B
+        tle9Bufordi36e4cwC7OtIieI/oND0B5lf2uo5mkQG8MZNDhjQHS4Qu3tesh8uzDLkXx4q+YoRPU
+        B7fxH2feSWJJ+pdp7F7g+rWub+B0xkxLdwe7ZmuphuunQuNzNkdpZeh3iu1GeK6lp/NmSvjvv++2
+        ctqxahBZv7tKM+baRRzYGGw/XWVbL5pzZTKRAGvv/9NiPsYu9096H5tjouekl7wW47xdfnk5pL4W
+        02kw9bcGk2/KPxpMpb3skyJqPvlUiAUzdWRMOp2ZVOcj/0xjR7t2DMtXHiNGAPnFw7U/LcxhShfJ
+        7P6tiHwG/ihCy15+pHlSYKg3j8VPKOvnA+8rD9NYP8rcTuROedX/AAAA//9kmEsOxDAIQ/fcKmLB
+        Bbj/WWZiP5qo7aaq1I8LsbGTKw8KZT2j6AuFb95zSpm3cYxDzJolz3sTZrazi5AUSLTWQzqcL2Za
+        XBYhiFpJai9melFY0cKS1jyyl/HwTSzLNzHzPnlm/D8TbRmpydB9HLlY6dZLMighieKSWg1fSfhk
+        tUtrxd5RgsXeBcjc3AMwDlg11lz23MWV1sMR92xaQaVVxdAArcdoWk79N40W0cNG7uwayhsRNuMd
+        xOUcS/w9FuzhorEb9MngA6Tbo8QPAAD//wMA7dg88nISAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:59:49 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 322C409D773A9D45000043BAC8C84FA1.1.1.m_5
+      NCBI-SID:
+      - 74F4837FFF66AC90_1486SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=74F4837FFF66AC90_1486SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:59:49 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NM_001256125.1&rettype=fasta&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAADRRPWvDUAzc/Sve2EIocaAdC0KD0qEZivZiQqBviBNs09/fu1MaeMrp807y++nz
+        e78fD69veC9jO96ut7ZO936Z13b+6Vufp/XSxvbkx48cn3dtW6Z5PS/9vrXfaenTvLXDrl2/TjaY
+        p3tG8EXQmFshB7A0/IKIBkkWKoT/zIw0gIEu8sy607GKpDMNBIOAppKEs9BdWXWhJQc8dwWpqMJO
+        BWKTD4g2FFkNosqk5tINcVJDETWYpRSeKfleMpOD6QBTJkYoLPEUHjaIRFyPjeQR6QYAHuRNV7/u
+        E1Rnjz1BbMalFK1zchEqQG+IgBzYzXRbHlSrVTb/75QxuC6hVVVXAwTK6uPxFqVEJBF/AAAA//9U
+        lcttAzEMRO/siuBBDbD/WqyZN9oghgM7Xoki5yf9NuHlHlwNHAeAON7o9nwwjUcwHBPeG6SBS4S7
+        ygPNHQoWLVfHwcxEa0+b+zahQkHA3V9KrGmqSfnoaz8gbumgqT10tIiDedVHreFUsW0DpJdJEQXq
+        wgsb6mgTfDzP3axTC72tF6gMvhgOiXqWbThAct3oxS3qr7Ty2FcGeOg/QrNQPavdZgXTC75Dfndt
+        6X+fGL0fMD8fjj5N8NzfMUfcmbreVdad5IosNuPYGQLI7AU9N7YJAlTmt5mypxc7up01yb0o/cEU
+        X6aF+JaZjuR3CXVVPDg+h85zvvZZI5BI40bUktcQFRtGD1YtQB1sPenW0GhNp/aiDnquia/3jwYj
+        aL1IUxZ2murHecKJrGoxtcavnXL4c2LUzxOGZPZ5I8VGo0L0Tb9DUBwSINmXEAy1y9wCA0+O6+3M
+        y4XqpPl8hM9rxyeiEsXKMi6IexSspWVFU5vYBurdjY7yxNlHoCYv1i9OsIqBK0p2M8n0tfHVMhdJ
+        pllgbXR3UErFx0Sto7gNpuMXetXZeRwn/ZwRfOppLfrhNPzFrdSMiAzAeJzWzxH6gLu9ummKN1sj
+        NzPMfZMEQUBM2Au4TZjaDE3oIhht79j9eC+7gINWBvMkwAg1eypcKjmbcHfBl3OwdJ8aN6fh5s55
+        6V/LdWEGTq5+a8EDnHm3Jl/bzBNB5C2XXA327ndD+KJkENi/X21Tt9q5JuldrdlTW/NIOC9uuFGx
+        H8OTu8ZZYDHJRlqSwS3DHZvc+v+q+gEAAP//AwAXvbVrSwkAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:59:53 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 322C409D773A9D45000031BAD2B40051.1.1.m_5
+      NCBI-SID:
+      - 8273700B4CF77965_7E71SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=8273700B4CF77965_7E71SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:59:52 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/issues/cassettes/test_602/test_602.yaml
+++ b/tests/issues/cassettes/test_602/test_602.yaml
@@ -1,0 +1,249 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NC_000006.11&rettype=fasta&seq_start=33415675&seq_stop=33422480&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAExRy2rDQAy871fsB7QhjhOn9FAQOqinUsrcS1oMCdR1iE/5+2qkNdTYu3rMSCP5
+        5U0/t3yGTdc99/2+OwzHw6Mbu93+aVtf52muy+l6GX+X+n2+ubvM01iHh2ofeu6Pm2vX1/fbZTrd
+        7lWWZZy+fu5FYapiIuoXbxMzBqEmyst9mCcEEIfAPAS3ofBX1bMoZLudZ1iiRDqQAHr8vAC7MeuO
+        NYLEGWVYUTyDkGBON2StJiqsZLICTFoRoPWFlqBzsOTLPx5di1kzmKhVeChO8aqFYqgduQXRnBiy
+        bsyrtxlhTVDKSW2IlZbY7YoIuOkqSig7F2LUGupIjJLEsQfzhT/GooXELkiIzh5glEsOiHeWPwAA
+        AP//VJfLccUwDAPv6orjAxtQ/7XE3AWdJJl5cfwsiR8AhN+6UIOJgi5NVyeIMwt7Unj/eZtaHkDc
+        toJ1NyfP0vfM4ig7StqHYnKLfm3M3CmvihjmlE6Ryz0oHcU4VOUa8oupotudr+lZLu3J7X2+tm1T
+        i/MIl2cXB5uV2hLeTQvThSnXXNmcWf5GAzAmW8G2aVscO7b9I036YZHen7bLp/J/0f+UKThdgBBj
+        aLKlpAHTHAIgKUDUnClI3j/dZGK3+ceSP+SXDVtsvpwCL4E0SCi7zD5PwpB4XxXhHFl3kH644zmV
+        R9qdBF6If6MjJG85W3BSt+MJaV0pEoQ09Z12dAJkXcAP6nMJzg+8Ic0N1D0nmFLMlIgPEtuFAcIm
+        cO7itlKIUZSLxikc9vFeRaoVEMKEjDTgLXGrVNM57tAVxJIb1xu1nKpvPeVIy47N93F4+1FqWaji
+        rAjJxZveSt6u4/e7NE/VVRAMTE5yBzUZdN8I8qT7nn/mA9Gf2ImoyFAxbLAw21XEBDWZlFE1vnhr
+        dcjPbVg3D/Jwxg3YmKtqkfYkQuoJ0N/Hj4dNoK0qEMJoBqNJIoC7ZAwi+SB4ReaYdrOX2HBdOwYJ
+        iyeGhbP1wCFyJk3nhPO49No+1q6kh0vO1RmiiRfFlrYC69ahqRWNuuQRujmmAIq6rNRTlqfVJUTh
+        vT5zXwjd6H9Eh3l7O/qtrBDYf6mcw+odMOg4anI5ujyOGLtlAKMCKusCaNsOglkKNS90EA7D7Lod
+        va14BwgLF8s8kA/5NNfHUYZWVHgSEiJDRadKjPKxbPz4MjVA0nvVGw4aBrcI+EYCKBUwgx+0vgPw
+        E+GhJ8se5q8icCvG5VnJ72jClhOUHSCdEVqiNGwIDsPUDPkpFZQvwEZNka1S+YB7cMIkA0oC6fmo
+        Iq7rptKlFN9xW0glR9xIT8XTxPpYNXqtFugDDYbDxt+IrgAZCb2REifP398weqDJh+5obNJdi+mJ
+        GRzqQoMjKRv7NVJs/ytmY+p+gr5VfjAiViqzkxaqRu6VQYMT83uEwsFq527ts9YpTOFDByG8BXg7
+        Wse09aYQu9WVUVZx1SVBogFxHp80CcbTbhpCtPMpVRBGkYhgvW6gq7jFMp84DkK4GTB6XzQptCn9
+        y93pYn9s2ER6np0viyi1GgvXX4Z5BTA9LMr02qdnr0MWishVxB8n79WE8RuX8NCICrnun6l3ouGP
+        6+9KTpfkcjMHevzyzVD2ELt3Hs9yEl7N22bIwPflJcoby5OpZezTixNZ+AwwVjy0AdRaq08eNuL+
+        1GQof+J7kQNnO6wp3yo0cL2oMB2tYJyD73FBsd85G8rXhRv/6Px/lmiO3Ls6/Lj0+JaQCipnnRcC
+        NXLNeWci/Np+ZpmMOXrwjqh+Lh11jCEcosRl4HHiZQmvhEWSYkZnHPVdQ7Al+ObJaltMwK/74n0q
+        dvnuXNMU5WXpSRYPehgYD8M6E35+jvPKqSHb9hUuO/TncItZlIp1Xmaml1hIh+TeXfF8v/4BAAD/
+        /4I0QwEAAAD//1SZyXEEMQwD/8pKxQcTUP6xuMRuaNZ2+ajZWY3EAwSw/G4H/SAl2HKvNXVxMzVV
+        yoycAm7fOh1CoqNj0+CnVUNg2KVJ0CDBFozM7Jj1H1VqXrFcm8kDjhhiOAg3fUfZKjCbjcRtmWaD
+        pXfvA1u2XcBKjh2pAhNy5byZAaRQGmW2CKBtDsApm1jtMzAkScPfyORBX8+hZs1ssb6wyV1gOjR7
+        0YuAQcs2ZloudHpUBfA4kBo95r4J0VPC+ghzwruMzNdjl93VkU2fvoVBEunqsCWJ8bqDuajRY3nY
+        gbS2PO2JyNTU9s+JEMqzN3EVnBvdOvDT4WyM3ejPk2U3mkEJfij5Dj5U/x5x4NV2kXwP/RgIW/3E
+        GIIEIMq7TYngROoO2iAKe9BidTAPKwDpD35GOsfbeYB24g2VMRsqkFDMSGMp54d07dkCFa1kZnOm
+        nRCfoHSQSnPBfaYeVZQ6Q2DgfXnBVxM0eFWyXrFJ/NFCGf9B4sAGMOympeSEA1+DCfv38Yq+UOLI
+        yZbzL29GmMuP+0n48BI9wbkopKXRp8OWoNzFc6JDhWv/+2ycyBSALZ3ODBcJeNScLyhaFrhKZoey
+        D8tA9UwZLYY+akenMYTq6VxPMvL5ddb+raUVz5D5i5iL2mH/LwUPzL7vaJE1ZJ5FxUBNu1RQ2qhf
+        TZ//zV60Jk0M9W69MDpDggBeScLbxn7LDJ6sJA+lmf7dL71xLUPjK5NC/JyADYVkuisH+ULhH3g1
+        UxJv1WxovFSrQdczJ2ICcZYN/xnFZ0BwTJAk4ECX4m6G7wzzsEr8GNyBFGEh7mJLB+tL7X976oRL
+        6+pqdDAvLT3x8hsZJxGUdd8qhrYyrX/cjZ7+QJRStlP7I8rc+34W/6on7maWKAEVpKWtAESf+D9V
+        mP4YzPfBa8fYqLiaen2KY1iAuofM79KUmteHMi1uK8zvlCtCam7rzZiplNspMyuXHW9yzaRD3YUW
+        awAxgsy6el7r7XUGtAJGkdEGgyDmciR2JR20NZlms8mQoesmNfdXnHcmeRmvGYKhJY5AJOVB4s4b
+        1jyxDE5XXGJGwYdADDHoXS5UBOUQkymrIZItl8fl5jOHQo1BpYueYQtNOoYorRkEdNCcPbsugzAX
+        gbGtLB8Dqjue1X2gn3rc6487Hzkv8bzLO3M48G1w8j14PyJmsQc+LrpX1voDAAD//wMAS3Z9i1Ab
+        AAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:59:55 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 322C409D773A9D4500004DBADA205F43.1.1.m_5
+      NCBI-SID:
+      - 4BD6F26C0123A982_7150SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=4BD6F26C0123A982_7150SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:59:55 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NM_006772.2&rettype=fasta&seq_start=4045&seq_stop=7024&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAExQTWvDMAy951fouEE3ktK1sMNA+KBdFkqny07DhDB8qBMSU9i/n56cwuKAJVl6
+        H3rrP77b9ng67Z/3r4f28PJ0bLuO3qfrRGuc05hXWn9znEsa6BJXEj3HdaQ4lHSLJeUfmpepjClT
+        Rw+fX73wuXvcUVliXoclzYVucUkxF+p2dL303ASVEFiYg124hUVQ1CAccFlei2yZBv9URUQxYb+N
+        NtYpasdHrBdoASVD9Hwron5/5bAF1uiU3AirGoS4ICtaAEoBCfCgFCPqIFzRGBr9wXrtaINIwQnQ
+        O4llQPEKV3pYgxV2DPBAL3rMHjeK3bhjd1FjOPdtQIaPh39WOFRKdgG+uqbuD3PiOnwDsu3RdQLX
+        hQgUO2J1orIhi8FwXfyWc/gDAAD//0yVwRXDMAhD72zF84EF2H+Wmi/htHlN3cTGQhIYQi4VAOwU
+        N0TLQbrRkgzmfiNWAOCKKynvBgVooctFeD7WFKdJ+aD5nR+zS7IXryff+Uw0eEaSCX+n3X0zRWQf
+        wxZFIW8IybPWDSO2lrKjPYAyU3CJ5kJ02KU3KwMuOfeMH+XRtj24S6k7vG8GtZSNTXrrodKavL1T
+        vJK1n80/DeX1ijFttdPyL3INXNVWy/LVx0zVf4oQEK4XrR9a52rhKZcWS4b2t9qK8GxGwbL0Uhln
+        tgAkcBoTtcSaqyyVJJFDw46k9BmKNCF++R+Ryeb3M4yJCtMQ9ov9djYng90Mq7Y+CCB0tkmJ4urN
+        BSLdm1ruNmcAzFXd/n3fAo0saQMfIWjtN21haGpcRU/odLrs3voGfFsU3oB6DVypltfqmy6uNuCi
+        ZUx2cVzNM92FToW1GsXYG/Yle4rT9kgOH6Vasyki1FwjStg0N0jNXTva4CqInpNhfhoZCZeJjUpT
+        1FdosW63Jjhdo1LLbYu3uWb6vNSop/CEFI08eBLcNbFdaC+rTvG5zNwD5YQ9b3qriL+h8usHabv2
+        4E6Lx6FTFqhlUvIFlvtNubBfmLP1cI4SyT0r6a/WQKs8NV4f1CsbLTfF1rlHJTFi+0QTHZIAChZn
+        RvwAAAD//wMA3oyx5UAIAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 15 Sep 2023 22:59:59 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - D0BD088E3BFC1F95000060D621F18DE4.1.1.m_5
+      NCBI-SID:
+      - 5822C2300E4CAD74_76C7SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=5822C2300E4CAD74_76C7SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 22:59:59 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=NM_006772.2&rettype=fasta&seq_start=7024&seq_stop=7024&tool=bioutils&email=biocommons-dev@googlegroups.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAFyMzQqCUBCF972HUHwt7IdaS9o66AFCzPSCem28Qb1950a0iDkcZub8UJh5SzYZ
+        h+JYh6o9ZePYuaoMzg96C6P55+syBavLfr6I1l/mTM2dh3igEjMRKDExTgdeYtDiuEbZc4uev5Ap
+        MtBojZ2ymIw9unLYk7JmyxK6T6RRYfsVdxJXmiTNhNkbAAD//wMA+XtUgM0AAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - close
+      Content-Disposition:
+      - attachment; filename="sequence.fasta"
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 15 Sep 2023 23:00:02 GMT
+      NCBI-PHID:
+      - D0BD088E3BFC1F9500004BD62D7CC847.1.1.m_5
+      NCBI-SID:
+      - E47344936623F373_BDF3SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=E47344936623F373_BDF3SID; domain=.nih.gov; path=/; expires=Sun, 15
+        Sep 2024 23:00:02 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 400
+      message: Bad Request
+version: 1

--- a/tests/issues/test_437.py
+++ b/tests/issues/test_437.py
@@ -55,6 +55,7 @@ class Test437_RMRP(unittest.TestCase):
             self.hdp, "NR_003051.3", "NC_000009.12", "splign"
         )
 
+    @pytest.mark.vcr
     def test_tx_start(self):
         hgvs_n = "NR_003051.3:n.1G>T"
         hgvs_g = "NC_000009.11:g.35658015C>A"
@@ -70,6 +71,7 @@ class Test437_RMRP(unittest.TestCase):
         assert var_gn.posedit.pos == var_n.posedit.pos
         assert str(var_gn) == hgvs_n
 
+    @pytest.mark.vcr
     def test_terminii(self):
         hgvs.global_config.mapping.strict_bounds = True
 
@@ -110,6 +112,7 @@ class Test437_RMRP(unittest.TestCase):
             self.am37.n_to_g(self.e2_n)
 
 
+@pytest.mark.vcr
 def test_oob_dup(parser, am37):
     """Intentionally preserve dup, derived from genomic sequence, when
     projecting to out-of-bounds transcript coordinates
@@ -129,6 +132,7 @@ def test_oob_dup(parser, am37):
     hgvs.global_config.mapping.strict_bounds = True
 
 
+@pytest.mark.vcr
 def test_invitae_examples(parser, am37):
     """bidirectional g↔t tests of out-of-bounds variants provided by Invitae"""
     invitae_examples = [

--- a/tests/issues/test_477.py
+++ b/tests/issues/test_477.py
@@ -126,6 +126,7 @@ tests = (
 )
 
 
+@pytest.mark.vcr
 @pytest.mark.parametrize("pair", tests, ids=[p["rs"] for p in tests])
 def test_pair(parser, am38, pair):
     var_c = parser.parse(pair["c"])

--- a/tests/issues/test_525.py
+++ b/tests/issues/test_525.py
@@ -1,6 +1,8 @@
 """https://github.com/biocommons/hgvs/issues/525"""
+import pytest
 
 
+@pytest.mark.vcr
 def test_525(parser, am38):
     """https://github.com/biocommons/hgvs/issues/525"""
 

--- a/tests/issues/test_602.py
+++ b/tests/issues/test_602.py
@@ -6,6 +6,7 @@ import hgvs
 from hgvs.exceptions import HGVSInvalidIntervalError
 
 
+@pytest.mark.vcr
 def test_602(parser, am37):
     """ensure that there's no ref check for variants beyond bounds of transcript"""
 

--- a/tests/test_hgvs_extras_babelfish.py
+++ b/tests/test_hgvs_extras_babelfish.py
@@ -1,3 +1,6 @@
+import pytest
+
+
 NORM_HGVS_VCF = [
     # Columns are: (normed-HGVS, non-normalized HGVS, VCF coordinates, non-norm VCF)
     # no-op
@@ -52,6 +55,7 @@ NORM_HGVS_VCF = [
 ]
 
 
+@pytest.mark.vcr
 def test_hgvs_to_vcf(parser, babelfish38):
     """
       49949___  400       410       420

--- a/tests/test_hgvs_variantmapper.py
+++ b/tests/test_hgvs_variantmapper.py
@@ -13,6 +13,7 @@ import hgvs.variantmapper
 from hgvs.exceptions import HGVSError, HGVSInvalidVariantError
 
 
+@pytest.mark.vcr
 def test_add_gene_symbol(am38, parser):
     ags = am38.add_gene_symbol
     var_g = parser.parse("NC_000007.13:g.21940852_21940908del")


### PR DESCRIPTION
The tests make network calls to https://eutils.ncbi.nlm.nih.gov, causing the tests to be slow and flaky.

This PR updates the pytest [vcrpy](https://vcrpy.readthedocs.io/en/latest/index.html) plugin from [pytest-vcr](https://pytest-vcr.readthedocs.io/en/latest/) to the actively maintained [pytest-recording](https://github.com/kiwicom/pytest-recording), which also allows for blocking network access to confirm that all network calls are mocked.

Slowest ten tests without network mocking:
```
============================================ slowest 10 durations ============================================
22.42s call     tests/test_hgvs_extras_babelfish.py::test_hgvs_to_vcf                                        
20.49s call     tests/issues/test_437.py::Test437_RMRP::test_terminii                                        
18.54s call     tests/issues/test_437.py::test_invitae_examples                                              
11.25s call     tests/issues/test_437.py::test_oob_dup                                                        
6.01s call     tests/issues/test_477.py::test_pair[GPHB5/GRCh37/rs1221379530]                                
5.97s call     tests/issues/test_602.py::test_602                                                             
5.87s call     tests/issues/test_477.py::test_pair[COX6A2/GRCh38/rs755670336]                                
5.81s call     tests/test_hgvs_variantmapper.py::test_add_gene_symbol                                        
5.76s call     tests/issues/test_477.py::test_pair[GPHB5/GRCh37/rs1380832691]                                
5.74s call     tests/issues/test_477.py::test_pair[COX6A2/GRCh38/rs764753905]    
```

Slowest ten tests with network mocking:
```
============================================ slowest 10 durations ============================================
1.86s call     tests/issues/test_04xx.py::Test_Issues::test_459_exception_when_ac_nonexistent
1.39s setup    tests/test_hgvs_dataproviders_uta.py::Test_hgvs_dataproviders_uta_with_pooling_without_cache::t
est_get_acs_for_protein_seq 
1.36s setup    tests/test_hgvs_variantmapper_cp_real.py::TestHgvsCToPReal::test_c_to_p_ext
1.34s setup    tests/test_hgvs_dataproviders_uta.py::TestUTAPool::test_get_acs_for_protein_seq
0.60s call     tests/test_hgvs_variantmapper_gcp.py::Test_VariantMapper::test_DNAH11_dbSNP_NM_001277115
0.49s call     tests/test_hgvs_variantmapper_gcp.py::Test_VariantMapper::test_DNAH11_dbSNP_NM_003777
0.39s call     tests/test_hgvs_variantmapper_gcp.py::Test_VariantMapper::test_JRK_dbSNP
0.39s call     tests/test_hgvs_variantmapper_gcp.py::Test_VariantMapper::test_ORAI1_dbSNP
0.38s call     tests/test_hgvs_variantmapper_gcp.py::Test_VariantMapper::test_real
0.29s call     tests/test_hgvs_variantmapper_gcp.py::Test_VariantMapper::test_FOLR3_dbSNP

```



See also:
https://til.simonwillison.net/pytest/pytest-recording-vcr