### PR TITLE
fix(#712): This fixes the broken make develop install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ keywords = [
     "hgvs",
     "variation"
     ]
-dynamic = ["version"]
+dynamic = ["version", "optional-dependencies"]
 
 [project.urls]
 "Homepage" = "https://github.com/biocommons/hgvs"
@@ -40,11 +40,10 @@ dynamic = ["version"]
 [project.scripts]
 "hgvs-shell" = "hgvs.shell:shell"
 
-
 [build-system]
 requires = [
-	 "setuptools >= 65.3",
-   	 "setuptools_scm[toml] ~= 7.0"
+	 "setuptools >= 69.0.2",
+   	 "setuptools_scm[toml] >= 8.0"
 	 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,17 @@ keywords = [
     ]
 dynamic = ["version", "optional-dependencies"]
 
+dependencies=[
+    "attrs >= 17.4.0",  # https://github.com/biocommons/hgvs/issues/473
+    "biocommons.seqrepo >= 0.6.5",
+    "bioutils >= 0.4.0,<1.0",
+    "configparser >= 3.3.0",
+    "ipython",
+    "parsley",
+    "psycopg2",
+    "six",
+]
+
 [project.urls]
 "Homepage" = "https://github.com/biocommons/hgvs"
 "Bug Tracker" = "https://github.com/biocommons/hgvs/issues"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[metadata]
+name = hgvs
+
 [options]
 zip_safe = True
 include_package_data = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,15 +7,6 @@ include_package_data = True
 packages = find_namespace:
 package_dir =
     =src
-install_requires =
-    attrs >= 17.4.0  # https://github.com/biocommons/hgvs/issues/473
-    biocommons.seqrepo >= 0.6.5
-    bioutils >= 0.4.0,<1.0
-    configparser >= 3.3.0
-    ipython
-    parsley
-    psycopg2
-    six
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
This PR fixes the broken make develop, by making sure that the optional dev dependencies are indicated as optional in pyproject.toml. 