### PR TITLE
fix: update gene symbol when it is `None` and `AssemblyMapper` normalizer

### DIFF
--- a/src/hgvs/assemblymapper.py
+++ b/src/hgvs/assemblymapper.py
@@ -88,8 +88,11 @@ class AssemblyMapper(VariantMapper):
         self.in_par_assume = in_par_assume
         self._norm = None
         if self.normalize:
+            vm = VariantMapper(hdp=hdp, replace_reference=replace_reference, 
+                               prevalidation_level=prevalidation_level, 
+                               add_gene_symbol=add_gene_symbol)
             self._norm = hgvs.normalizer.Normalizer(
-                hdp, alt_aln_method=alt_aln_method, validate=False
+                hdp, alt_aln_method=alt_aln_method, validate=False, variantmapper=vm
             )
         self._assembly_map = {
             k: v for k, v in hdp.get_assembly_map(self.assembly_name).items() if k.startswith("NC_")

--- a/src/hgvs/variantmapper.py
+++ b/src/hgvs/variantmapper.py
@@ -590,7 +590,7 @@ class VariantMapper(object):
         return seq
 
     def _update_gene_symbol(self, var, symbol):
-        if not symbol:
+        if symbol is None or not symbol:
             symbol = self.hdp.get_tx_identity_info(var.ac).get("hgnc", None)
         var.gene = symbol
         return var


### PR DESCRIPTION
Two fixes:

1. The `_update_gene_symbol` of `VariantMapper` class did not update symbol when it is `None`. 

2. The normalizer of `AssemblyMapper` uses a `VariantMapper` configured inconsistently from `AssemblyMapper` itself. The `AssemblyMapper._norm` is a `Normalizer` object. `Normalizer` has a field `vm` of `VariantMapper` class. In the current code, when initializing an `AssemblyMapper` object with the argument of a different value from `global_config` (e.g. `add_gene_symbol=True`, the `vm` will be created using `global_config`, rather than the parameters passed to `AssemblyMapper`. This is confusing, because the mappers are configured differently and can bring unexpected behaviors. 

The fix passes a `VariantMapper` object initialized using the same arguments as `AssemblyMapper` object.