### PR TITLE
feat: update default data version config

### DIFF
--- a/docs/modules/config.rst
+++ b/docs/modules/config.rst
@@ -7,58 +7,6 @@ Configuration
 .. automodule:: hgvs.config
 
 
-The defaults are::
+The defaults are:
 
-  [mapping]
-  alt_aln_method = splign
-  assembly = GRCh38
-  in_par_assume = X
-  inferred_p_is_uncertain = True
-  normalize = True
-  prevalidation_level = EXTRINSIC
-  replace_reference = True
-  
-  # strict_bounds: require transcript variants to be within transcript sequence bounds
-  strict_bounds = True
-  
-  # add gene symbol: add gene symbol on converted variants
-  add_gene_symbol = False
-  
-  
-  [formatting]
-  max_ref_length = 0
-  p_3_letter = True
-  p_term_asterisk = False
-  p_init_met = True
-  
-  [validator]
-  strict = True
-  
-  
-  [normalizer]
-  cross_boundaries = False
-  shuffle_direction = 3
-  validate = True
-  window_size = 20
-  
-  
-  [lru_cache]
-  maxsize = 100
-  
-  
-  [uta]
-  pooling = False
-  pool_min = 1
-  pool_max = 10
-  
-  prd_uta_version = uta_20210129
-  stg_uta_version = uta_20210129
-  dev_uta_version = uta_20210129
-  public_host = uta.biocommons.org
-  local_host = localhost
-  public_prd = postgresql://anonymous:anonymous@${public_host}/uta/${prd_uta_version}
-  public_stg = postgresql://anonymous:anonymous@${public_host}/uta/${stg_uta_version}
-  public_dev = postgresql://anonymous:anonymous@${public_host}/uta_dev/${dev_uta_version}
-  local_prd  = postgresql://anonymous:anonymous@${local_host}/uta/${prd_uta_version}
-  local_stg  = postgresql://anonymous:anonymous@${local_host}/uta/${stg_uta_version}
-  local_dev  = postgresql://anonymous:anonymous@${local_host}/uta_dev/${dev_uta_version}
+.. literalinclude:: ../../src/hgvs/_data/defaults.ini

--- a/misc/docker-compose.yml
+++ b/misc/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     # Test:
     # psql -XAt postgres://anonymous@localhost/uta -c 'select count(*) from transcript'
     # 249909
-    image: biocommons/uta:uta_20180821
+    image: biocommons/uta:uta_20210129
     volumes:
       - uta_vol:/var/lib/postgresql/data
     network_mode: host

--- a/misc/docker-compose.yml
+++ b/misc/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     # Test:
     # psql -XAt postgres://anonymous@localhost/uta -c 'select count(*) from transcript'
     # 249909
-    image: biocommons/uta:uta_20210129
+    image: biocommons/uta:uta_20210129b
     volumes:
       - uta_vol:/var/lib/postgresql/data
     network_mode: host

--- a/src/hgvs/_data/defaults.ini
+++ b/src/hgvs/_data/defaults.ini
@@ -40,9 +40,9 @@ pooling = False
 pool_min = 1
 pool_max = 10
 
-prd_uta_version = uta_20180821
-stg_uta_version = uta_20180821
-dev_uta_version = uta_20180821
+prd_uta_version = uta_20210129b
+stg_uta_version = uta_20210129b
+dev_uta_version = uta_20210129b
 public_host = uta.biocommons.org
 local_host = localhost
 public_prd = postgresql://anonymous:anonymous@${public_host}/uta/${prd_uta_version}

--- a/tests/test_hgvs_dataproviders_uta.py
+++ b/tests/test_hgvs_dataproviders_uta.py
@@ -66,20 +66,20 @@ class UTA_Base:
 
     def test_get_tx_for_gene(self):
         tig = self.hdp.get_tx_for_gene("VHL")
-
+        
         expected_data = [
-            ("NM_000551.4",	"NC_000003.12"), # added in UTA at 2021-01-31 
-            ("NM_198156.2",	"NC_018914.2"),
-            ("ENST00000345392",	"NC_000003.11")
+            ("NM_001354723.1", "NC_000003.11"),
+            ("NM_198156.2", "NC_018914.2"),
+            ("ENST00000345392", "NC_000003.11"),
         ]
         found = 0
         for hgnc, cds_start_i, cds_end_i, tx_ac, alt_ac, alt_aln_method in tig:
             for t_tx_ac, t_alt_ac in expected_data:
                 if t_tx_ac == tx_ac and t_alt_ac == alt_ac:
                     found += 1
-        
+
         self.assertEqual(found, 3)
-        
+
     def test_get_tx_for_gene_invalid_gene(self):
         tig = self.hdp.get_tx_for_gene("GENE")
         self.assertEqual(0, len(tig))

--- a/tests/test_hgvs_dataproviders_uta.py
+++ b/tests/test_hgvs_dataproviders_uta.py
@@ -73,7 +73,7 @@ class UTA_Base:
             ("ENST00000345392", "NC_000003.11"),
         ]
         found = 0
-        for hgnc, cds_start_i, cds_end_i, tx_ac, alt_ac, alt_aln_method in tig:
+        for _, _, _, tx_ac, alt_ac, _ in tig:
             for t_tx_ac, t_alt_ac in expected_data:
                 if t_tx_ac == tx_ac and t_alt_ac == alt_ac:
                     found += 1

--- a/tests/test_hgvs_dataproviders_uta.py
+++ b/tests/test_hgvs_dataproviders_uta.py
@@ -66,8 +66,20 @@ class UTA_Base:
 
     def test_get_tx_for_gene(self):
         tig = self.hdp.get_tx_for_gene("VHL")
-        self.assertEqual(16, len(tig))
 
+        expected_data = [
+            ("NM_000551.4",	"NC_000003.12"), # added in UTA at 2021-01-31 
+            ("NM_198156.2",	"NC_018914.2"),
+            ("ENST00000345392",	"NC_000003.11")
+        ]
+        found = 0
+        for hgnc, cds_start_i, cds_end_i, tx_ac, alt_ac, alt_aln_method in tig:
+            for t_tx_ac, t_alt_ac in expected_data:
+                if t_tx_ac == tx_ac and t_alt_ac == alt_ac:
+                    found += 1
+        
+        self.assertEqual(found, 3)
+        
     def test_get_tx_for_gene_invalid_gene(self):
         tig = self.hdp.get_tx_for_gene("GENE")
         self.assertEqual(0, len(tig))


### PR DESCRIPTION
close #733

Update default UTA version to `20210129b`

Did a search for other likely places where version values were hardcoded. Noticed that `defaults.ini` seems to be copy-pasted into the `config` section of the API reference, so replaced that with a [literalinclude](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-literalinclude) directive to reduce work in the future.

(I'm guessing I need to update some cassettes or something, so making this a draft for now)