### PR TITLE
refactor: use importlib instead of pkg_resources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies=[
     "biocommons.seqrepo >= 0.6.5",
     "bioutils >= 0.4.0,<1.0",
     "configparser >= 3.3.0",
+    "importlib_resources",
     "ipython",
     "parsley",
     "psycopg2",

--- a/src/hgvs/__init__.py
+++ b/src/hgvs/__init__.py
@@ -53,8 +53,7 @@ import logging
 import re
 import sys
 import warnings
-
-import pkg_resources
+from importlib import metadata
 
 from .config import global_config  # noqa (importing symbol)
 
@@ -71,11 +70,11 @@ if sys.version_info < (3, 6):
 
 _is_released_version = False
 try:
-    __version__ = pkg_resources.get_distribution("hgvs").version
+    __version__ = metadata.version("hgvs")
     # TODO: match other valid release tags, like .post\d+
     if re.match(r"^\d+\.\d+\.\d+$", __version__) is not None:
         _is_released_version = True
-except pkg_resources.DistributionNotFound:
+except metadata.PackageNotFoundError:
     warnings.warn("can't get __version__ because %s package isn't installed" % __package__, Warning)
     __version__ = None
 

--- a/src/hgvs/config.py
+++ b/src/hgvs/config.py
@@ -33,7 +33,6 @@ from configparser import ConfigParser, ExtendedInterpolation
 from copy import copy
 from importlib import resources
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -116,6 +115,6 @@ def _val_xform(v):
 
 
 _default_config = Config()
-_default_config.read_stream(resources.files(__name__) / "_data"/ "defaults.ini")
+_default_config.read_stream(resources.files(__name__) / "_data" / "defaults.ini")
 
 global_config = copy(_default_config)

--- a/src/hgvs/config.py
+++ b/src/hgvs/config.py
@@ -31,7 +31,10 @@ import logging
 import re
 from configparser import ConfigParser, ExtendedInterpolation
 from copy import copy
-from importlib import resources
+try:
+    from importlib.resources import files as resources_files
+except ImportError:
+    from importlib_resources import files as resources_files
 
 logger = logging.getLogger(__name__)
 
@@ -115,6 +118,6 @@ def _val_xform(v):
 
 
 _default_config = Config()
-_default_config.read_stream(resources.files(__package__) / "_data" / "defaults.ini")
+_default_config.read_stream(resources_files(__package__) / "_data" / "defaults.ini")
 
 global_config = copy(_default_config)

--- a/src/hgvs/config.py
+++ b/src/hgvs/config.py
@@ -31,8 +31,8 @@ import logging
 import re
 from configparser import ConfigParser, ExtendedInterpolation
 from copy import copy
+from importlib import resources
 
-from pkg_resources import resource_stream
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +53,7 @@ class Config:
 
     def read_stream(self, flo):
         """read configuration from ini-formatted file-like object"""
-        self._cp.read_string(flo.read().decode("ascii"))
+        self._cp.read_string(flo.open("rb").read().decode("ascii"))
 
     def __copy__(self):
         new_config = Config.__new__(Config)
@@ -116,6 +116,6 @@ def _val_xform(v):
 
 
 _default_config = Config()
-_default_config.read_stream(resource_stream(__name__, "_data/defaults.ini"))
+_default_config.read_stream(resources.files(__name__) / "_data"/ "defaults.ini")
 
 global_config = copy(_default_config)

--- a/src/hgvs/config.py
+++ b/src/hgvs/config.py
@@ -115,6 +115,6 @@ def _val_xform(v):
 
 
 _default_config = Config()
-_default_config.read_stream(resources.files(__name__) / "_data" / "defaults.ini")
+_default_config.read_stream(resources.files(__package__) / "_data" / "defaults.ini")
 
 global_config = copy(_default_config)

--- a/tests/test_hgvs_grammar_full.py
+++ b/tests/test_hgvs_grammar_full.py
@@ -4,8 +4,7 @@ import pprint
 import re
 import unittest
 from sys import version_info
-
-import pkg_resources
+from importlib import resources
 
 #
 # Tests of the grammar
@@ -52,7 +51,7 @@ class TestGrammarFull(unittest.TestCase):
         """ensure that all rules in grammar have tests"""
 
         grammar_rule_re = re.compile(r"^(\w+)")
-        grammar_fn = pkg_resources.resource_filename("hgvs", "_data/hgvs.pymeta")
+        grammar_fn = resources.files("hgvs") / "_data" / "hgvs.pymeta"
         with open(grammar_fn, "r") as f:
             grammar_rules = set(r.group(1) for r in filter(None, map(grammar_rule_re.match, f)))
 

--- a/tests/test_hgvs_grammar_full.py
+++ b/tests/test_hgvs_grammar_full.py
@@ -4,7 +4,10 @@ import pprint
 import re
 import unittest
 from sys import version_info
-from importlib import resources
+try:
+    from importlib.resources import files as resources_files
+except ImportError:
+    from importlib_resources import files as resources_files
 
 #
 # Tests of the grammar
@@ -51,7 +54,7 @@ class TestGrammarFull(unittest.TestCase):
         """ensure that all rules in grammar have tests"""
 
         grammar_rule_re = re.compile(r"^(\w+)")
-        grammar_fn = resources.files("hgvs") / "_data" / "hgvs.pymeta"
+        grammar_fn = resources_files("hgvs") / "_data" / "hgvs.pymeta"
         with open(grammar_fn, "r") as f:
             grammar_rules = set(r.group(1) for r in filter(None, map(grammar_rule_re.match, f)))
 


### PR DESCRIPTION
remember to remove `importlib_resources` dependency when upgrading to 3.10-12