### PR TITLE
#744 - babelfish vcf conversion accept contig accessions as chrom names

### DIFF
--- a/src/hgvs/extras/babelfish.py
+++ b/src/hgvs/extras/babelfish.py
@@ -33,6 +33,10 @@ class Babelfish:
         )
         self.ac_to_name_map = make_ac_name_map(assembly_name)
         self.name_to_ac_map = make_name_ac_map(assembly_name)
+        # We need to accept accessions as chromosome names, so add them pointing at themselves
+        accessions = list(self.name_to_ac_map.values())
+        self.name_to_ac_map.update({ac: ac for ac in accessions})
+
 
     def hgvs_to_vcf(self, var_g):
         """**EXPERIMENTAL**

--- a/src/hgvs/extras/babelfish.py
+++ b/src/hgvs/extras/babelfish.py
@@ -34,9 +34,7 @@ class Babelfish:
         self.ac_to_name_map = make_ac_name_map(assembly_name)
         self.name_to_ac_map = make_name_ac_map(assembly_name)
         # We need to accept accessions as chromosome names, so add them pointing at themselves
-        accessions = list(self.name_to_ac_map.values())
-        self.name_to_ac_map.update({ac: ac for ac in accessions})
-
+        self.name_to_ac_map.update({ac: ac for ac in self.name_to_ac_map.values()})
 
     def hgvs_to_vcf(self, var_g):
         """**EXPERIMENTAL**

--- a/tests/test_hgvs_extras_babelfish.py
+++ b/tests/test_hgvs_extras_babelfish.py
@@ -93,3 +93,8 @@ def test_vcf_to_hgvs(parser, babelfish38):
             hgvs_g = _v2h(*v)
             hgvs_string = hgvs_g.format()
             assert hgvs_string == expected_hgvs_string
+
+
+def test_vcf_to_hgvs_contig_chrom(parser, babelfish38):
+    hgvs_g = babelfish38.vcf_to_g_hgvs("NC_000006.12", 49949409, "GAA", "G")
+    assert hgvs_g.format() == "NC_000006.12:g.49949413_49949414del"


### PR DESCRIPTION
Fix for #744 