### PR TITLE
Resolve testing warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dynamic = ["version", "optional-dependencies"]
 
 dependencies=[
     "attrs >= 17.4.0",  # https://github.com/biocommons/hgvs/issues/473
-    "biocommons.seqrepo >= 0.6.5",
+    "biocommons.seqrepo >= 0.6.10",
     "bioutils >= 0.4.0,<1.0",
     "configparser >= 3.3.0",
     "importlib_resources",


### PR DESCRIPTION
The first warning (re: yoyo) was indirect, from seqrepo. The root cause is https://todo.sr.ht/~olly/yoyo/94 (~2y old). It was resolved in https://github.com/biocommons/biocommons.seqrepo/pull/177 by silencing that specific warning.

The second warning in #759 disappeared when my virtualenv was recreated. 