### PR TITLE
cicd: fix deploy action url + action versions + caching

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -e .[dev]          
+          pip install -e .[dev]
 
       - name: Test with pytest
         run: |
@@ -80,7 +80,7 @@ jobs:
 
     environment:
       name: pypi
-      url: https://pypi.org/p/biocommons.seqrepo
+      url: https://pypi.org/p/hgvs
     permissions:
       id-token: write  # mandatory for trusted publishing
 
@@ -93,14 +93,14 @@ jobs:
         echo tags = ${{ startsWith(github.ref, 'refs/tags') }}
         echo "::endgroup::"
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.10"
         cache: pip
-        cache-dependency-path: '**/setup.cfg'
+        cache-dependency-path: '**/pyproject.toml'
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Some small fixes

* Use correct deploy URL (I think this is just aesthetic but it's still a little confusing if not fixed)
* Update action versions (avert future deprecation warnings)
* Use correct caching target