### PR TITLE
update pyproject.toml from most recent python-package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,9 @@
 *.bak
 *.cover
 *.egg
+*.egg-info
 *.egg-info/
+*.enc
 *.log
 *.manifest
 *.mo
@@ -11,6 +13,9 @@
 *.py.cover
 *.py[cod]
 *.py[codz]
+*.pyc
+*.pyo
+*.rej
 *.sage.py
 *.so
 *.spec
@@ -21,6 +26,7 @@
 .Python
 .abstra/
 .cache
+.claude
 .coverage
 .coverage.*
 .cursorignore
@@ -33,6 +39,7 @@
 .idea
 .installed.cfg
 .ipynb_checkpoints
+.keys
 .mypy_cache/
 .nox/
 .pdm-build/
@@ -105,6 +112,7 @@ profile_default/
 sdist/
 share/python-wheels/
 target/
+tmp/
 var/
 venv.bak/
 venv/

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2019 hgvs Contributors
+   Copyright 2025 Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dev = [
   "sphinxcontrib-fulltoc >= 1.1",
   "toml-sort",
   "tox-uv>=1.28",
-  "vcrpy"
+  "vcrpy",
 ]
 
 [project]
@@ -33,9 +33,9 @@ classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python",
   "Topic :: Scientific/Engineering :: Bio-Informatics",
   "Topic :: Scientific/Engineering :: Medical Science Apps.",
@@ -74,7 +74,7 @@ align = ["uta-align~=0.3"]
 
 [project.urls]
 Documentation = "https://hgvs.readthedocs.io/"
-Homepage = "https://github.com/biocommons/hgvs"
+Homepage = "https://github.com/biocommons/hgvs/"
 Issues = "https://github.com/biocommons/hgvs/issues"
 Repository = "https://github.com/biocommons/hgvs/"
 
@@ -166,7 +166,7 @@ testpaths = ["tests"]
 fix = true
 line-length = 100
 src = ["src", "tests"]
-target-version = "py39"
+target-version = "py313"
 
 [tool.ruff.format]
 docstring-code-format = true
@@ -197,9 +197,12 @@ ignore = [
   "E117",
   "E501",
   "E731",
+  "N801",
+  "N802",
   "PLR0913",
+  "RET504",
   "S321",
-  "W191"
+  "W191",
 ]
 select = [
   "A", # https://docs.astral.sh/ruff/rules/#flake8-builtins-a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ align = ["uta-align~=0.3"]
 [project.urls]
 Documentation = "https://hgvs.readthedocs.io/"
 Homepage = "https://github.com/biocommons/hgvs/"
-Issues = "https://github.com/biocommons/hgvs/issues"
+Issues = "https://github.com/biocommons/hgvs/issues/"
 Repository = "https://github.com/biocommons/hgvs/"
 
 [tool.coverage]


### PR DESCRIPTION
Updates pyproject.toml from the python-package template, primarily to ignore ruff warnings that differ from biocommons conventions. These changes should simplify https://github.com/biocommons/hgvs/pull/814/