### PR TITLE
Revert "fix(uta): decode URL-encoded creds from UTA_DB_URL"

### DIFF
--- a/src/hgvs/dataproviders/uta.py
+++ b/src/hgvs/dataproviders/uta.py
@@ -66,7 +66,7 @@ def connect(
 ):
     """Connect to a UTA database instance and return a UTA interface instance.
 
-    :param db_url: URL for database connection. Credentials must be URL-encoded if they contain special characters
+    :param db_url: URL for database connection
     :type db_url: string
     :param pooling: whether to use connection pooling (postgresql only)
     :type pooling: bool
@@ -546,8 +546,8 @@ class UTA_postgresql(UTABase):
             host=self.url.hostname,
             port=self.url.port,
             database=self.url.database,
-            user=urlparse.unquote(self.url.username),
-            password=urlparse.unquote(self.url.password),
+            user=self.url.username,
+            password=self.url.password,
             application_name=self.application_name + "/" + hgvs.__version__,
         )
         if self.pooling:


### PR DESCRIPTION
Reverts biocommons/hgvs#825

This change risks breaking existing clients that pass a string that contains special characters.

Data providers should use username and passwords as passed to it; if they need to be unquoted, that should be the caller's responsibility, not the client's. This is akin to unicode encoding/decoding or converting between UTC/local at the code perimeter, not within it.

@korikuzma @andreasprlic : What do you make of this assessment?
