### PR TITLE
fix: add --merge flag to dependabot automerge command

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Enable auto-merge for minor/patch updates
         if: steps.metadata.outputs.update-type != 'version-update:semver-major'
-        run: gh pr merge --auto "$PR_URL"
+        run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- `gh pr merge --auto "$PR_URL"` in `.github/workflows/dependabot-automerge.yml` fails on every dependabot PR because current `gh` requires an explicit merge strategy in non-interactive CI contexts.
- Adds `--merge` (this repo prefers merge commits per its git-workflow convention).

Fixes #852

## Test plan
- [x] Confirmed the failure mode on PR #844/#851 (`--merge, --rebase, or --squash required when not running interactively`)
- [ ] After merge, verify a subsequent dependabot PR's automerge check passes