### PR TITLE
fix: isolate network-dependent UTA tests from default test runs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,7 @@ tox-uv = "tox_uv"
 ty = "ty"
 
 [tool.pytest.ini_options]
-addopts = "-s -v -x --strict-markers -m 'not extra' --doctest-modules --cov=src"
+addopts = "-s -v -x --strict-markers -m 'not extra and not network' --doctest-modules --cov=src"
 doctest_optionflags = [
   "ALLOW_BYTES",
   "ALLOW_UNICODE",
@@ -150,7 +150,7 @@ doctest_optionflags = [
   "NORMALIZE_WHITESPACE"
 ]
 markers = [
-  "network: tests that require network connectivity",
+  "network: uncachable tests that always require network connectivity",
   "slow: slow tests that should be run infrequently",
 
   "extra",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,10 @@ import os
 
 import pytest
 
-import hgvs.easy
+import hgvs.dataproviders.uta
 from hgvs.assemblymapper import AssemblyMapper
 from hgvs.extras.babelfish import Babelfish
+from hgvs.parsers import Parser
 from hgvs.variantmapper import VariantMapper
 from support import CACHE
 
@@ -30,14 +31,13 @@ def vcr_config(request):  # noqa: ARG001
     }
 
 
-hgvs.easy.hdp = hgvs.dataproviders.uta.connect(
-    mode=os.environ.get("HGVS_CACHE_MODE", "run"), cache=CACHE
-)
+_hdp = hgvs.dataproviders.uta.connect(mode=os.environ.get("HGVS_CACHE_MODE", "run"), cache=CACHE)
+_parser = Parser()
 
 
 @pytest.fixture(scope="session", autouse=True)
 def parser():
-    return hgvs.easy.parser
+    return _parser
 
 
 @pytest.fixture(scope="session")
@@ -57,7 +57,7 @@ def am38(hdp):
 
 @pytest.fixture(scope="session")
 def hdp():
-    return hgvs.easy.hdp
+    return _hdp
 
 
 @pytest.fixture(scope="session")
@@ -68,8 +68,8 @@ def babelfish38(hdp):
 def pytest_report_header(config):  # noqa: ARG001
     env_vars = ["UTA_DB_URL", "HGVS_SEQREPO_URL", "HGVS_CACHE_MODE"]
     rv = [f"{ev}={os.environ.get(ev)}" for ev in sorted(env_vars)]
-    rv += [f"hgvs.easy.hdp={hgvs.easy.hdp.url}"]
-    rv += [f"{hgvs.easy.hdp.seqfetcher.source=}"]
+    rv += [f"hdp={_hdp.url}"]
+    rv += [f"{_hdp.seqfetcher.source=}"]
     return "\n".join(rv)
 
 

--- a/tests/test_hgvs_dataproviders_uta.py
+++ b/tests/test_hgvs_dataproviders_uta.py
@@ -127,6 +127,7 @@ class Test_hgvs_dataproviders_uta_UTA_default_with_pooling(unittest.TestCase, UT
         )
 
 
+@pytest.mark.network
 class Test_hgvs_dataproviders_uta_with_pooling_without_cache(unittest.TestCase, UTA_Base):
     """
     Currently used to test pool errors, since we need to reach out to


### PR DESCRIPTION
## Summary

- Marks `Test_hgvs_dataproviders_uta_with_pooling_without_cache` (and its subclass `TestUTAPool`) with `@pytest.mark.network` — this class connects with no cache and always requires a live UTA database connection by design (it tests connection-pool/failover behavior). The `network` marker was already declared in `pyproject.toml` but unused.
- Excludes `network`-marked tests from default `addopts` (`-m 'not extra and not network'`), so a plain `pytest`/`make test` run never dials out.
- Fixes `tests/conftest.py`, which imported `hgvs.easy` for convenience — but `hgvs.easy` connects with no `mode`/`cache` at *import time* (by design, for library end users), so merely importing it during test collection opened a real network connection to the live UTA DB, before conftest's own cache-backed `connect()` call could take effect. Replaced with direct `hgvs.dataproviders.uta`/`hgvs.parsers.Parser` imports and module-level `_hdp`/`_parser` singletons.
- Updated the `network` marker's description in `pyproject.toml` for clarity: "uncachable tests that always require network connectivity".

**Tests are now fully isolated from network by default.** Verified by running the full suite with an unresolvable `UTA_DB_URL` (simulating no network access) — `make test` passes (420 passed, 44 skipped, 28 deselected, 4 xfailed), where previously it failed with `psycopg.OperationalError: failed to resolve host`. Reece also ran from laptop with network disabled.

Network-only tests can still be run on demand with `pytest -m network` (requires live UTA connectivity). `HGVS_CACHE_MODE=learn`/`verify` continue to work as before for regenerating/verifying the bundled test cache against a live DB.

Fixes #867

## Test plan

- [x] `make test` passes with a deliberately unresolvable `UTA_DB_URL` (no network fallback possible)
- [x] `pytest --collect-only -m network` collects exactly the pool/connection-loss tests
- [x] `pytest -m network` still reaches the live UTA DB when run explicitly
- [x] Full default suite passes unchanged otherwise (420 passed, 44 skipped, 28 deselected, 4 xfailed)