### PR TITLE
fix: add ref_n to AARefAlt so protein del/delins can be validated

### DIFF
--- a/src/hgvs/edit.py
+++ b/src/hgvs/edit.py
@@ -187,6 +187,22 @@ class AARefAlt(Edit):
         self.ref = aa_to_aa1(self.ref)
         self.alt = aa_to_aa1(self.alt)
 
+    @property
+    def ref_n(self):
+        """
+        returns the number of amino acids in `ref`, or None if `ref` is unspecified.
+
+        Unlike `NARefAlt.ref_n`, a numeric `ref` is not supported: protein syntax
+        has no counted deletion (e.g. `del5`), so `ref` is always a sequence.
+
+        >>> AARefAlt("KLM").ref_n
+        3
+        >>> AARefAlt("").ref_n
+        >>> AARefAlt(None).ref_n
+
+        """
+        return len(self.ref) if self.ref else None
+
     def format(self, conf=None):
         if self.ref is None and self.alt is None:
             # raise HGVSError("RefAlt: ref and alt sequences are both undefined")

--- a/tests/issues/test_05xx.py
+++ b/tests/issues/test_05xx.py
@@ -41,3 +41,14 @@ class Test_Issues(unittest.TestCase):
         var_c = self.hp.parse_hgvs_variant(hgvs)
         var_p = self.am38.c_to_p(var_c)
         assert str(var_p) == "NP_001628.1:p.(Gln2Ter)"
+
+    def test_573(self):
+        """https://github.com/biocommons/hgvs/issues/573"""
+
+        # Validating a protein deletion raised AttributeError: 'AARefAlt' object
+        # has no attribute 'ref_n'. The parser leaves ref empty for p. del and
+        # delins, so the deletion length is unspecified and the length check
+        # must be skipped rather than fail.
+        for hgvs_p in ("NP_001087241.1:p.K550_E554del", "NP_001087241.1:p.K550_E554delinsR"):
+            var_p = self.hp.parse_hgvs_variant(hgvs_p)
+            assert self.hv.validate(var_p)

--- a/tests/test_hgvs_edit.py
+++ b/tests/test_hgvs_edit.py
@@ -55,6 +55,12 @@ class Test_Edit(unittest.TestCase):
         self.assertEqual(str(hgvs.edit.AARefAlt("", "T").type), "delins")
         self.assertEqual(str(hgvs.edit.AARefAlt("AA", "T").type), "delins")
         self.assertEqual(str(hgvs.edit.AARefAlt("A", "TT").type), "delins")
+        # ref lengths; an unspecified ref has no length (issues #573, #727)
+        self.assertEqual(hgvs.edit.AARefAlt("AA", None).ref_n, 2)
+        self.assertEqual(hgvs.edit.AARefAlt("AA", "T").ref_n, 2)
+        self.assertIsNone(hgvs.edit.AARefAlt("", None).ref_n)
+        self.assertIsNone(hgvs.edit.AARefAlt("", "T").ref_n)
+        self.assertIsNone(hgvs.edit.AARefAlt(None, "TT").ref_n)
 
     def test_AASub(self):
         self.assertEqual(str(hgvs.edit.AASub("A", "T")), "Thr")


### PR DESCRIPTION
`PosEdit.validate()` reads `edit.ref_n` for `del` and `delins` edits, but `ref_n` was only
defined on `NARefAlt` and `Inv`. The grammar builds protein deletions as
`AARefAlt(ref='', alt=None)` and protein delins as `AARefAlt(ref='', alt=alt)`, and both report
`type` `'del'`/`'delins'`, so validating any protein deletion raised:

```
AttributeError: 'AARefAlt' object has no attribute 'ref_n'
```

This adds the missing property. @markgene diagnosed it correctly in #727; this differs from the
patch linked there in returning `None` rather than `0` for an empty ref, for the reason below.

### Why `None` and not `0`

The parser never captures a reference sequence for `p.del`/`p.delins`, so the deletion length is
unspecified and the length check has to be skipped. Returning `0` turns the crash into a wrong
answer on the very input reported in #573:

```
>>> hv.validate(hp.parse_hgvs_variant("NP_001087241.1:p.K550_E554del"))
HGVSInvalidVariantError: Length implied by coordinates must equal sequence deletion length
```

With `None` it returns `True`. Where a ref *is* present — `c_to_p` builds `AARefAlt` with a real
amino acid sequence — `ref_n` is its length and the check runs as intended.

Unlike `NARefAlt.ref_n` this does not accept a numeric ref: protein syntax has no counted
deletion (`del5`), so `ref` is always a sequence.

`NARefAlt` and `AARefAlt` are the only edits whose `type` can be `del` or `delins`, so with this
both of them define `ref_n`. `AASub` inherits the property but overrides `type` to `sub`; `AAFs`,
`AAExt`, `Dup`, `Repeat`, `NACopy`, `Inv` and `Conv` likewise return constant types and never
reach that branch.

### Tests

`tests/issues/test_05xx.py::test_573` covers both reported forms through the parser and
`IntrinsicValidator`. It needs no data provider, so it runs offline and adds nothing to the test
cache. `tests/test_hgvs_edit.py::test_AARefAlt` pins the property itself, including `ref=None`,
which a bare `len()` would raise `TypeError` on.

Both fail on main with the `AttributeError` and pass with the fix. Full suite: 421 passed,
44 skipped, 28 deselected, 4 xfailed (420 before, +1 for the new test).

I also checked the `c_to_p` path from #727 against the mock data source, where the ref is
non-empty:

```
NM_999999.1:c.4_15del    -> MOCK:p.(Lys2_Ala5del)       ref='KAKA' ref_n=4 span=4  VALID
NM_999994.1:c.20_25del   -> MOCK:p.(Ala7_Arg9delinsGly) ref='AFR'  ref_n=3 span=3  VALID
```

so the length check agrees with the coordinates rather than firing spuriously.

Not fixed here, because the root cause is different and lives in `altseq_to_hgvsp`: validating a
`c_to_p` result still raises `AttributeError` for the `init_met` shape (an `Edit` assigned into
the posedit slot) and for the no-protein shape (`edit="0"`, a plain `str`). Happy to open a
separate issue for those if useful.

Fixes #573
Fixes #727
